### PR TITLE
Add Fluent UI landing page with navigation and footer

### DIFF
--- a/platforma/index.html
+++ b/platforma/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>Basketball Amateur League</title>
   </head>
   <body>
     <div id="root"></div>

--- a/platforma/src/App.jsx
+++ b/platforma/src/App.jsx
@@ -1,48 +1,17 @@
-// src/App.jsx
-import { useState, useEffect } from 'react';
-import { initializeIcons } from '@fluentui/react';
-import { PrimaryButton, TextField, Stack } from '@fluentui/react';
-import { db } from './firebase';
-import { collection, addDoc, getDocs } from 'firebase/firestore';
+import { initializeIcons, Stack } from '@fluentui/react';
+import Navbar from './components/Navbar';
+import ImageCarousel from './components/ImageCarousel';
+import Footer from './components/Footer';
 
 initializeIcons();
 
-function App() {
-  const [text, setText] = useState('');
-  const [items, setItems] = useState([]);
-
-  const handleSubmit = async () => {
-    if (text.trim()) {
-      await addDoc(collection(db, "items"), { text });
-      setText('');
-      fetchItems();
-    }
-  };
-
-  const fetchItems = async () => {
-    const querySnapshot = await getDocs(collection(db, "items"));
-    const data = querySnapshot.docs.map(doc => doc.data().text);
-    setItems(data);
-  };
-
-  useEffect(() => {
-    fetchItems();
-  }, []);
-
+export default function App() {
   return (
-    <Stack tokens={{ childrenGap: 10 }} style={{ padding: 20 }}>
-      <TextField
-        label="Enter text"
-        value={text}
-        onChange={(e, newValue) => setText(newValue)}
-      />
-      <PrimaryButton text="Submit" onClick={handleSubmit} />
-      
-      <ul>
-        {items.map((item, index) => (<li key={index}>{item}</li>))}
-      </ul>
+    <Stack tokens={{ childrenGap: 20 }}>
+      <Navbar />
+      <ImageCarousel />
+      <Footer />
     </Stack>
   );
 }
 
-export default App;

--- a/platforma/src/components/Footer.jsx
+++ b/platforma/src/components/Footer.jsx
@@ -1,0 +1,10 @@
+import { Stack, Text } from '@fluentui/react';
+
+export default function Footer() {
+  return (
+    <Stack horizontalAlign="center" styles={{ root: { padding: 20, background: '#f3f2f1' } }}>
+      <Text variant="small">© 2023 Amateur Basketball League</Text>
+    </Stack>
+  );
+}
+

--- a/platforma/src/components/ImageCarousel.jsx
+++ b/platforma/src/components/ImageCarousel.jsx
@@ -1,0 +1,28 @@
+import { useState } from 'react';
+import { IconButton, Image, Stack } from '@fluentui/react';
+
+const images = [
+  'https://placehold.co/800x300?text=Slide+1',
+  'https://placehold.co/800x300?text=Slide+2',
+  'https://placehold.co/800x300?text=Slide+3',
+];
+
+export default function ImageCarousel() {
+  const [index, setIndex] = useState(0);
+  const prev = () => setIndex((index - 1 + images.length) % images.length);
+  const next = () => setIndex((index + 1) % images.length);
+
+  return (
+    <Stack
+      horizontal
+      verticalAlign="center"
+      tokens={{ childrenGap: 8 }}
+      styles={{ root: { maxWidth: 800, margin: '20px auto' } }}
+    >
+      <IconButton iconProps={{ iconName: 'ChevronLeft' }} ariaLabel="Previous" onClick={prev} />
+      <Image src={images[index]} width={800} height={300} alt={`slide ${index + 1}`} />
+      <IconButton iconProps={{ iconName: 'ChevronRight' }} ariaLabel="Next" onClick={next} />
+    </Stack>
+  );
+}
+

--- a/platforma/src/components/Navbar.jsx
+++ b/platforma/src/components/Navbar.jsx
@@ -1,0 +1,24 @@
+import { CommandBar } from '@fluentui/react';
+
+const navItems = [
+  { key: 'home', text: 'Home', href: '#' },
+  { key: 'news', text: 'News', href: '#' },
+  { key: 'calendar', text: 'Calendar', href: '#' },
+  { key: 'results', text: 'Results', href: '#' },
+  { key: 'schedule', text: 'Schedule', href: '#' },
+  { key: 'tables', text: 'Tables', href: '#' },
+  { key: 'stats', text: 'Stats', href: '#' },
+  { key: 'teams', text: 'Teams', href: '#' },
+  { key: 'players', text: 'Players', href: '#' },
+];
+
+export default function Navbar() {
+  return (
+    <CommandBar
+      items={navItems}
+      ariaLabel="Main navigation"
+      styles={{ root: { padding: '0 16px', background: '#f3f2f1' } }}
+    />
+  );
+}
+

--- a/platforma/src/firebase.js
+++ b/platforma/src/firebase.js
@@ -1,7 +1,6 @@
 // Import the functions you need from the SDKs you need
 import { initializeApp } from "firebase/app";
 import { getFirestore } from "firebase/firestore";
-import { getAnalytics } from "firebase/analytics";
 // TODO: Add SDKs for Firebase products that you want to use
 // https://firebase.google.com/docs/web/setup#available-libraries
 
@@ -20,7 +19,6 @@ const firebaseConfig = {
 // Initialize Firebase
 const app = initializeApp(firebaseConfig);
 const db = getFirestore(app);
-const analytics = getAnalytics(app);
 
 
 export { db };

--- a/platforma/src/index.css
+++ b/platforma/src/index.css
@@ -1,68 +1,9 @@
 :root {
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
-  font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
 }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
-  min-height: 100vh;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
-}


### PR DESCRIPTION
## Summary
- create top navigation bar using Fluent UI CommandBar
- add image carousel and footer
- simplify styling and remove unused Firebase analytics reference

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68933d0e95c08326b5663481288b944a