### PR TITLE
feat: add theme switcher with Fluent provider

### DIFF
--- a/platforma/package-lock.json
+++ b/platforma/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@fluentui/react": "^8.123.4",
+        "@fluentui/react-components": "^9.68.2",
         "@fluentui/react-icons": "^2.0.307",
         "@types/react": "^18.3.23",
         "@types/react-dom": "^18.3.7",
@@ -329,6 +330,15 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@ctrl/tinycolor": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.6.1.tgz",
+      "integrity": "sha512-SITSV6aIXsuVNV3f3O0f2n/cgyEDWoSqtZMYiAmcsYHydcKrOz3gUxB/iXd/Qf08+IZX4KpgNbvUdMBmWz+kcA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@emotion/hash": {
@@ -1541,6 +1551,39 @@
       "integrity": "sha512-6m8+P+dE/RPl4OPzjTxcTbQ0rGeRyeTvAi9KwIffBVCiAMKrfXfLZaqD1F+m8t4B5/Q5aHsMozOgirkH1F5oMQ==",
       "license": "Apache-2.0"
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
+      "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/devtools": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/devtools/-/devtools-0.2.1.tgz",
+      "integrity": "sha512-8PHJLbD6VhBh+LJ1uty/Bz30qs02NXCE5u8WpOhSewlYXUWl03GNXknr9AS2yaAWJEQaY27x7eByJs44gODBcw==",
+      "peerDependencies": {
+        "@floating-ui/dom": ">=1.5.4"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.3.tgz",
+      "integrity": "sha512-uZA413QEpNuhtb3/iIKoYMSK07keHPYeXF02Zhd6e213j+d1NamLix/mCLxBUDW/Gx52sPH2m+chlUsyaBs/Ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.3",
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "license": "MIT"
+    },
     "node_modules/@fluentui/date-time-utilities": {
       "version": "8.6.10",
       "resolved": "https://registry.npmjs.org/@fluentui/date-time-utilities/-/date-time-utilities-8.6.10.tgz",
@@ -1599,6 +1642,15 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/@fluentui/keyboard-keys": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@fluentui/keyboard-keys/-/keyboard-keys-9.0.8.tgz",
+      "integrity": "sha512-iUSJUUHAyTosnXK8O2Ilbfxma+ZyZPMua5vB028Ys96z80v+LFwntoehlFsdH3rMuPsA8GaC1RE7LMezwPBPdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.1"
+      }
+    },
     "node_modules/@fluentui/merge-styles": {
       "version": "8.6.14",
       "resolved": "https://registry.npmjs.org/@fluentui/merge-styles/-/merge-styles-8.6.14.tgz",
@@ -1607,6 +1659,15 @@
       "dependencies": {
         "@fluentui/set-version": "^8.2.24",
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@fluentui/priority-overflow": {
+      "version": "9.1.15",
+      "resolved": "https://registry.npmjs.org/@fluentui/priority-overflow/-/priority-overflow-9.1.15.tgz",
+      "integrity": "sha512-/3jPBBq64hRdA416grVj+ZeMBUIaKZk2S5HiRg7CKCAV1JuyF84Do0rQI6ns8Vb9XOGuc4kurMcL/UEftoEVrg==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.1"
       }
     },
     "node_modules/@fluentui/react": {
@@ -1635,6 +1696,658 @@
         "@types/react-dom": ">=16.8.0 <19.0.0",
         "react": ">=16.8.0 <19.0.0",
         "react-dom": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-accordion": {
+      "version": "9.8.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-accordion/-/react-accordion-9.8.3.tgz",
+      "integrity": "sha512-NEmiF+l/V9ToWwrruursX/xWwPSskkU9S+1sjCN/F/rNgPtlDEyFmVSuGPpKddmUIi1YEJuozqedEx2ybsru4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-aria": "^9.16.2",
+        "@fluentui/react-context-selector": "^9.2.4",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-motion": "^9.10.1",
+        "@fluentui/react-motion-components-preview": "^0.8.1",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-accordion/node_modules/@fluentui/react-context-selector": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.2.4.tgz",
+      "integrity": "sha512-4QJjaBWoJSW+Vu6XRT0A9j3h2RGdXNUj9ur6ljdXwG13DoE69v03cDVF8GT3jiXWO3veNJntelI0BS99Qb5wzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0",
+        "scheduler": ">=0.19.0 <=0.23.0"
+      }
+    },
+    "node_modules/@fluentui/react-accordion/node_modules/scheduler": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/@fluentui/react-alert": {
+      "version": "9.0.0-beta.124",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-alert/-/react-alert-9.0.0-beta.124.tgz",
+      "integrity": "sha512-yFBo3B5H9hnoaXxlkuz8wRz04DEyQ+ElYA/p5p+Vojf19Zuta8DmFZZ6JtWdtxcdnnQ4LvAfC5OYYlzdReozPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-avatar": "^9.6.29",
+        "@fluentui/react-button": "^9.3.83",
+        "@fluentui/react-icons": "^2.0.239",
+        "@fluentui/react-jsx-runtime": "^9.0.39",
+        "@fluentui/react-tabster": "^9.21.5",
+        "@fluentui/react-theme": "^9.1.19",
+        "@fluentui/react-utilities": "^9.18.10",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-aria": {
+      "version": "9.16.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-aria/-/react-aria-9.16.2.tgz",
+      "integrity": "sha512-7ly8FJPG7Ra/oNmN1S9RNr4YiuKGTK5vkSUS6ojbyY2BCBiU96SQWDyHRmge4JKuqHUeioRumqrnQcxmmT/Skw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-avatar": {
+      "version": "9.9.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-avatar/-/react-avatar-9.9.3.tgz",
+      "integrity": "sha512-0Z0ueMrtneioQbg4MOFQ3aYwhEsDyNApj1zaoPVd6vj4YLU3NgNp2ryL5HgEE5TtjYltrTXcRVqid8RDchMXGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-badge": "^9.4.2",
+        "@fluentui/react-context-selector": "^9.2.4",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-popover": "^9.12.3",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-tooltip": "^9.8.2",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-avatar/node_modules/@fluentui/react-context-selector": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.2.4.tgz",
+      "integrity": "sha512-4QJjaBWoJSW+Vu6XRT0A9j3h2RGdXNUj9ur6ljdXwG13DoE69v03cDVF8GT3jiXWO3veNJntelI0BS99Qb5wzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0",
+        "scheduler": ">=0.19.0 <=0.23.0"
+      }
+    },
+    "node_modules/@fluentui/react-avatar/node_modules/scheduler": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/@fluentui/react-badge": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-badge/-/react-badge-9.4.2.tgz",
+      "integrity": "sha512-jCTHsfhIY5bHsvnw/uuhzlDQl4I//trEJTR7wgBhxWq3T50LOe0wCCBbh7ik+YAVregoXk59Y7J6oet1oJOhOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-breadcrumb": {
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-breadcrumb/-/react-breadcrumb-9.3.3.tgz",
+      "integrity": "sha512-RAa16tcJi/dBLS/+qn2AO/PvnUpVQjLCfUmBiUQaGeJ6uo2qQ7bbGjSVIbdvC2yo0pZ4PhNRPyLcFdT3w4RpMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-aria": "^9.16.2",
+        "@fluentui/react-button": "^9.6.3",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-link": "^9.6.2",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-button": {
+      "version": "9.6.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-button/-/react-button-9.6.3.tgz",
+      "integrity": "sha512-+x8cNTjKPoQvu+paZ1wjWc+oOjlcFSJLhIHmaxIrtK3FE/93WQwk7rwmKDJ7QF1Jf7ghiUsmgRfDGfuNe1IQbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.16.2",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-card": {
+      "version": "9.4.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-card/-/react-card-9.4.3.tgz",
+      "integrity": "sha512-jt5Xjnl00O1vXNH/Zlrr5dehmHHX4wllFzVv4CyctW1X97U6ruyaow3RTwLXhkPV0chPJo7mTfItQrnmKtyKnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-text": "^9.6.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-carousel": {
+      "version": "9.8.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-carousel/-/react-carousel-9.8.3.tgz",
+      "integrity": "sha512-etmp7bCzYDCRFk5S3lV56aZN2iyH79O8vYylsKVAYOQzFZvY+Xcmgiyj3i5h5wJV2fJKwBp6Vi64ClHURwz0XA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-aria": "^9.16.2",
+        "@fluentui/react-button": "^9.6.3",
+        "@fluentui/react-context-selector": "^9.2.4",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-tooltip": "^9.8.2",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1",
+        "embla-carousel": "^8.5.1",
+        "embla-carousel-autoplay": "^8.5.1",
+        "embla-carousel-fade": "^8.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-carousel/node_modules/@fluentui/react-context-selector": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.2.4.tgz",
+      "integrity": "sha512-4QJjaBWoJSW+Vu6XRT0A9j3h2RGdXNUj9ur6ljdXwG13DoE69v03cDVF8GT3jiXWO3veNJntelI0BS99Qb5wzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0",
+        "scheduler": ">=0.19.0 <=0.23.0"
+      }
+    },
+    "node_modules/@fluentui/react-carousel/node_modules/scheduler": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/@fluentui/react-checkbox": {
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-checkbox/-/react-checkbox-9.5.2.tgz",
+      "integrity": "sha512-xb6apCPe2hHLIAdmZ8oHu6FQkc/tNG/MH69DvJ0r7muHCD/MqQUjsvi00BJcmLuPOCsbfIL9kzYtraGY4oLhMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.4.2",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-label": "^9.3.2",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-color-picker": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-color-picker/-/react-color-picker-9.2.2.tgz",
+      "integrity": "sha512-STR94ApqxR+nv6AS+9OX5gDd28fgl766deTz+9AodxI50UfEv+aWwL5ihiPSOzjc6ypTkdWZSV5s3Jr4w6iM5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@ctrl/tinycolor": "^3.3.4",
+        "@fluentui/react-context-selector": "^9.2.4",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-color-picker/node_modules/@fluentui/react-context-selector": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.2.4.tgz",
+      "integrity": "sha512-4QJjaBWoJSW+Vu6XRT0A9j3h2RGdXNUj9ur6ljdXwG13DoE69v03cDVF8GT3jiXWO3veNJntelI0BS99Qb5wzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0",
+        "scheduler": ">=0.19.0 <=0.23.0"
+      }
+    },
+    "node_modules/@fluentui/react-color-picker/node_modules/scheduler": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/@fluentui/react-combobox": {
+      "version": "9.16.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-combobox/-/react-combobox-9.16.3.tgz",
+      "integrity": "sha512-H1pR687K99iSpXInI0IyRt4IoC0F7VJvv69rmOX4/193jKX1CXJLNK9yEwReArLP+NJAC949TB5iMFTXIncqXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.16.2",
+        "@fluentui/react-context-selector": "^9.2.4",
+        "@fluentui/react-field": "^9.4.2",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-portal": "^9.7.2",
+        "@fluentui/react-positioning": "^9.20.2",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-combobox/node_modules/@fluentui/react-context-selector": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.2.4.tgz",
+      "integrity": "sha512-4QJjaBWoJSW+Vu6XRT0A9j3h2RGdXNUj9ur6ljdXwG13DoE69v03cDVF8GT3jiXWO3veNJntelI0BS99Qb5wzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0",
+        "scheduler": ">=0.19.0 <=0.23.0"
+      }
+    },
+    "node_modules/@fluentui/react-combobox/node_modules/scheduler": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/@fluentui/react-components": {
+      "version": "9.68.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-components/-/react-components-9.68.2.tgz",
+      "integrity": "sha512-5r4Pi2rNslPr18ewWP/xpisZKHFQFzYozYy2aYnvAIIiZic4dkCF2lxAix3nXJghNSiSQZszgRUd7YYPka1xFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-accordion": "^9.8.3",
+        "@fluentui/react-alert": "9.0.0-beta.124",
+        "@fluentui/react-aria": "^9.16.2",
+        "@fluentui/react-avatar": "^9.9.3",
+        "@fluentui/react-badge": "^9.4.2",
+        "@fluentui/react-breadcrumb": "^9.3.3",
+        "@fluentui/react-button": "^9.6.3",
+        "@fluentui/react-card": "^9.4.3",
+        "@fluentui/react-carousel": "^9.8.3",
+        "@fluentui/react-checkbox": "^9.5.2",
+        "@fluentui/react-color-picker": "^9.2.2",
+        "@fluentui/react-combobox": "^9.16.3",
+        "@fluentui/react-dialog": "^9.14.3",
+        "@fluentui/react-divider": "^9.4.2",
+        "@fluentui/react-drawer": "^9.9.3",
+        "@fluentui/react-field": "^9.4.2",
+        "@fluentui/react-image": "^9.3.2",
+        "@fluentui/react-infobutton": "9.0.0-beta.102",
+        "@fluentui/react-infolabel": "^9.4.3",
+        "@fluentui/react-input": "^9.7.2",
+        "@fluentui/react-label": "^9.3.2",
+        "@fluentui/react-link": "^9.6.2",
+        "@fluentui/react-list": "^9.4.1",
+        "@fluentui/react-menu": "^9.19.3",
+        "@fluentui/react-message-bar": "^9.6.3",
+        "@fluentui/react-motion": "^9.10.1",
+        "@fluentui/react-nav": "^9.3.3",
+        "@fluentui/react-overflow": "^9.5.3",
+        "@fluentui/react-persona": "^9.5.3",
+        "@fluentui/react-popover": "^9.12.3",
+        "@fluentui/react-portal": "^9.7.2",
+        "@fluentui/react-positioning": "^9.20.2",
+        "@fluentui/react-progress": "^9.4.2",
+        "@fluentui/react-provider": "^9.22.2",
+        "@fluentui/react-radio": "^9.5.2",
+        "@fluentui/react-rating": "^9.3.2",
+        "@fluentui/react-search": "^9.3.2",
+        "@fluentui/react-select": "^9.4.2",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-skeleton": "^9.4.2",
+        "@fluentui/react-slider": "^9.5.2",
+        "@fluentui/react-spinbutton": "^9.5.2",
+        "@fluentui/react-spinner": "^9.7.2",
+        "@fluentui/react-swatch-picker": "^9.4.2",
+        "@fluentui/react-switch": "^9.4.2",
+        "@fluentui/react-table": "^9.18.3",
+        "@fluentui/react-tabs": "^9.9.2",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-tag-picker": "^9.7.3",
+        "@fluentui/react-tags": "^9.7.3",
+        "@fluentui/react-teaching-popover": "^9.6.3",
+        "@fluentui/react-text": "^9.6.2",
+        "@fluentui/react-textarea": "^9.6.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-toast": "^9.6.3",
+        "@fluentui/react-toolbar": "^9.6.3",
+        "@fluentui/react-tooltip": "^9.8.2",
+        "@fluentui/react-tree": "^9.12.3",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@fluentui/react-virtualizer": "9.0.0-alpha.102",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-dialog": {
+      "version": "9.14.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-dialog/-/react-dialog-9.14.3.tgz",
+      "integrity": "sha512-88zYoa7bOqjzKyR+7L1Cykr9zHx2kH2aOahalZb5ogocSjXP2mGTXhC2S5nuRKwYzmc0Q05jOJJDLxdk9zfFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.16.2",
+        "@fluentui/react-context-selector": "^9.2.4",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-motion": "^9.10.1",
+        "@fluentui/react-motion-components-preview": "^0.8.1",
+        "@fluentui/react-portal": "^9.7.2",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-dialog/node_modules/@fluentui/react-context-selector": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.2.4.tgz",
+      "integrity": "sha512-4QJjaBWoJSW+Vu6XRT0A9j3h2RGdXNUj9ur6ljdXwG13DoE69v03cDVF8GT3jiXWO3veNJntelI0BS99Qb5wzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0",
+        "scheduler": ">=0.19.0 <=0.23.0"
+      }
+    },
+    "node_modules/@fluentui/react-dialog/node_modules/scheduler": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/@fluentui/react-divider": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-divider/-/react-divider-9.4.2.tgz",
+      "integrity": "sha512-+deTs9M/FswHSC2zUJU8YUniUx2IiUOnXdfpKd3/pK0caCF1cLA6Vrr36TdTCLBImJMQXj4dU7Gzoq9XCXacRw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-drawer": {
+      "version": "9.9.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-drawer/-/react-drawer-9.9.3.tgz",
+      "integrity": "sha512-380Riyv6mfo05p5+tDu8XwmGPRt/gX1PxWkFVx69so1V0w/WAytafHDbcKhiQThiBs+1bquY0mHc1jiUXjzbyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-dialog": "^9.14.3",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-motion": "^9.10.1",
+        "@fluentui/react-portal": "^9.7.2",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-field": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-field/-/react-field-9.4.2.tgz",
+      "integrity": "sha512-11ayN4VoMiyX4U5/fi97AZV7UE587oUr0Uv7Pi02eGW2K0Hc/czf3UxRS1DTwwamVJPgIMHPiraF36b/X2oihg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-context-selector": "^9.2.4",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-label": "^9.3.2",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-field/node_modules/@fluentui/react-context-selector": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.2.4.tgz",
+      "integrity": "sha512-4QJjaBWoJSW+Vu6XRT0A9j3h2RGdXNUj9ur6ljdXwG13DoE69v03cDVF8GT3jiXWO3veNJntelI0BS99Qb5wzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0",
+        "scheduler": ">=0.19.0 <=0.23.0"
+      }
+    },
+    "node_modules/@fluentui/react-field/node_modules/scheduler": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/@fluentui/react-focus": {
@@ -1684,6 +2397,511 @@
         "react": ">=16.8.0 <19.0.0"
       }
     },
+    "node_modules/@fluentui/react-image": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-image/-/react-image-9.3.2.tgz",
+      "integrity": "sha512-pLn3Me4pWKZ6eCC74zjk0YOq4nPlCMM7Sql4Ee5uYyscAqpmkl2fue8fPOWT1tar8FI342KpDZWTYoUWWbiFcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-infobutton": {
+      "version": "9.0.0-beta.102",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-infobutton/-/react-infobutton-9.0.0-beta.102.tgz",
+      "integrity": "sha512-3kA4F0Vga8Ds6JGlBajLCCDOo/LmPuS786Wg7ui4ZTDYVIMzy1yp2XuVcZniifBFvEp0HQCUoDPWUV0VI3FfzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-icons": "^2.0.237",
+        "@fluentui/react-jsx-runtime": "^9.0.36",
+        "@fluentui/react-label": "^9.1.68",
+        "@fluentui/react-popover": "^9.9.6",
+        "@fluentui/react-tabster": "^9.21.0",
+        "@fluentui/react-theme": "^9.1.19",
+        "@fluentui/react-utilities": "^9.18.7",
+        "@griffel/react": "^1.5.14",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-infolabel": {
+      "version": "9.4.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-infolabel/-/react-infolabel-9.4.3.tgz",
+      "integrity": "sha512-lVyAINXxKBWp7a+c3L8G4VNEjBBepvtpdKGSrio+YQlmwJzqY3HmcE1YxNJyEI6iw5Wk29fEgs2PgpV7yDhsmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-label": "^9.3.2",
+        "@fluentui/react-popover": "^9.12.3",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <19.0.0",
+        "@types/react-dom": ">=16.8.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-input": {
+      "version": "9.7.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-input/-/react-input-9.7.2.tgz",
+      "integrity": "sha512-F8F1inTs3eNz+5GMDThgMmYhQyofEomAEVQnpzxvhhMwBbabMrA57Leh0xyVGGzYzl8o4GZqJxrBEzIkvfddtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.4.2",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-label": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-label/-/react-label-9.3.2.tgz",
+      "integrity": "sha512-TVYXC/dG5ck6fI2tpt+krZv6vYDAqJajIuSdoTs1IWYyg0CkKQXpPWSP7ghrlsmWPF4BKiTfaGZw+DgIR4lOXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-link": {
+      "version": "9.6.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-link/-/react-link-9.6.2.tgz",
+      "integrity": "sha512-X7IJsC3PSQ0Wt6ETIOWW1+ByNCR2paxE4U3SnPrslCAtV845f/isI61STXKmVCSnK8y8fnLqWIVuPqPhMfDJog==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-list": {
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-list/-/react-list-9.4.1.tgz",
+      "integrity": "sha512-QR4MUulhSSaRmR5S3sRv64ca2KDYaA8c3OLTBcH1XhQYoPG8pgIrNSEiQlgkfn6ejUBtlv/imBbyG0qTHFKZZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-checkbox": "^9.5.2",
+        "@fluentui/react-context-selector": "^9.2.4",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <19.0.0",
+        "@types/react-dom": ">=16.8.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-list/node_modules/@fluentui/react-context-selector": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.2.4.tgz",
+      "integrity": "sha512-4QJjaBWoJSW+Vu6XRT0A9j3h2RGdXNUj9ur6ljdXwG13DoE69v03cDVF8GT3jiXWO3veNJntelI0BS99Qb5wzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0",
+        "scheduler": ">=0.19.0 <=0.23.0"
+      }
+    },
+    "node_modules/@fluentui/react-list/node_modules/scheduler": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/@fluentui/react-menu": {
+      "version": "9.19.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-menu/-/react-menu-9.19.3.tgz",
+      "integrity": "sha512-ZiXtTPk8SE8bS/zKIQdgu3nMNQwtJNocmIunb7ZzOnHN02Joh7R9klzyN9H4ZxwgwIKmRGmyJZzTp/D/8CczXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.16.2",
+        "@fluentui/react-context-selector": "^9.2.4",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-portal": "^9.7.2",
+        "@fluentui/react-positioning": "^9.20.2",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-menu/node_modules/@fluentui/react-context-selector": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.2.4.tgz",
+      "integrity": "sha512-4QJjaBWoJSW+Vu6XRT0A9j3h2RGdXNUj9ur6ljdXwG13DoE69v03cDVF8GT3jiXWO3veNJntelI0BS99Qb5wzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0",
+        "scheduler": ">=0.19.0 <=0.23.0"
+      }
+    },
+    "node_modules/@fluentui/react-menu/node_modules/scheduler": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/@fluentui/react-message-bar": {
+      "version": "9.6.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-message-bar/-/react-message-bar-9.6.3.tgz",
+      "integrity": "sha512-gFeZb/WIBdpNrJ9Q3GoxPzYOwZ37MnbVxny8frO29cL0kZKYF9gbaBQ2qo12/YK4SMs/dw1usf8As551X3jZBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-button": "^9.6.3",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-link": "^9.6.2",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1",
+        "react-transition-group": "^4.4.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <19.0.0",
+        "@types/react-dom": ">=16.8.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-motion": {
+      "version": "9.10.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-motion/-/react-motion-9.10.1.tgz",
+      "integrity": "sha512-DMHRWzWoei4/FCV9ziQ9M4GkY8P24Ld8ouPjH5Eopurg/fGua2AOVDkm/sY2AdjsWSJ1oDGqS6xMXRYm/u6FtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <19.0.0",
+        "@types/react-dom": ">=16.8.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-motion-components-preview": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-motion-components-preview/-/react-motion-components-preview-0.8.1.tgz",
+      "integrity": "sha512-TeU3nNeOapIyLd15T3jBArEsdrsZoknW4U/RJv6dFOe0aV2IRQ86wnKbD8eVmXxc9cLQ1UoWxF549YfQwxyKKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-motion": "*",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-nav": {
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-nav/-/react-nav-9.3.3.tgz",
+      "integrity": "sha512-smzXtC1j3iMddi2GAwe8xv5e77Mr6PtrLnnrctpvRpUdMqKi5pnjXAqnErHe9JP05FuYC7DoNTQue4SXNgzC1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-aria": "^9.16.2",
+        "@fluentui/react-button": "^9.6.3",
+        "@fluentui/react-context-selector": "^9.2.4",
+        "@fluentui/react-divider": "^9.4.2",
+        "@fluentui/react-drawer": "^9.9.3",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-motion": "^9.10.1",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-tooltip": "^9.8.2",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-nav/node_modules/@fluentui/react-context-selector": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.2.4.tgz",
+      "integrity": "sha512-4QJjaBWoJSW+Vu6XRT0A9j3h2RGdXNUj9ur6ljdXwG13DoE69v03cDVF8GT3jiXWO3veNJntelI0BS99Qb5wzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0",
+        "scheduler": ">=0.19.0 <=0.23.0"
+      }
+    },
+    "node_modules/@fluentui/react-nav/node_modules/scheduler": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/@fluentui/react-overflow": {
+      "version": "9.5.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-overflow/-/react-overflow-9.5.3.tgz",
+      "integrity": "sha512-FAq96FkHp+3/0QA+pYSKwSTQpFifacPbEMkt2rAQWMnhxXXuJFhBzLrdqK0HFIT5SijkKNcROMe8YdSl4RdK7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/priority-overflow": "^9.1.15",
+        "@fluentui/react-context-selector": "^9.2.4",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-overflow/node_modules/@fluentui/react-context-selector": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.2.4.tgz",
+      "integrity": "sha512-4QJjaBWoJSW+Vu6XRT0A9j3h2RGdXNUj9ur6ljdXwG13DoE69v03cDVF8GT3jiXWO3veNJntelI0BS99Qb5wzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0",
+        "scheduler": ">=0.19.0 <=0.23.0"
+      }
+    },
+    "node_modules/@fluentui/react-overflow/node_modules/scheduler": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/@fluentui/react-persona": {
+      "version": "9.5.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-persona/-/react-persona-9.5.3.tgz",
+      "integrity": "sha512-xZwVjw9dYGR9QVZT7O9KVFmtFII+4JSFdbLLsdaWdPwuGVUqYMuuwESyu6aAROIWjXU8GAkFlhXXMUAQ//aGVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-avatar": "^9.9.3",
+        "@fluentui/react-badge": "^9.4.2",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-popover": {
+      "version": "9.12.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-popover/-/react-popover-9.12.3.tgz",
+      "integrity": "sha512-LNzzZghFzpfCDCxl2Sk5aRoCiAhjr86HgwS9ENkV9SiN30TiD9naRF33+zWVKTZwY3ZfRHEC/yo8BH1OXmamcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.16.2",
+        "@fluentui/react-context-selector": "^9.2.4",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-portal": "^9.7.2",
+        "@fluentui/react-positioning": "^9.20.2",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-popover/node_modules/@fluentui/react-context-selector": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.2.4.tgz",
+      "integrity": "sha512-4QJjaBWoJSW+Vu6XRT0A9j3h2RGdXNUj9ur6ljdXwG13DoE69v03cDVF8GT3jiXWO3veNJntelI0BS99Qb5wzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0",
+        "scheduler": ">=0.19.0 <=0.23.0"
+      }
+    },
+    "node_modules/@fluentui/react-popover/node_modules/scheduler": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/@fluentui/react-portal": {
+      "version": "9.7.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-portal/-/react-portal-9.7.2.tgz",
+      "integrity": "sha512-UC12+PsfrtAB+WrT39A8l86Szu2SXh7CUOf6q7+lJ2AWDdt93cYNQOU4QuLotoDebGuXZW4xMiB6QHy0sUGFiw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1",
+        "use-disposable": "^1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
     "node_modules/@fluentui/react-portal-compat-context": {
       "version": "9.0.13",
       "resolved": "https://registry.npmjs.org/@fluentui/react-portal-compat-context/-/react-portal-compat-context-9.0.13.tgz",
@@ -1695,6 +2913,844 @@
       "peerDependencies": {
         "@types/react": ">=16.14.0 <19.0.0",
         "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-positioning": {
+      "version": "9.20.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-positioning/-/react-positioning-9.20.2.tgz",
+      "integrity": "sha512-nqj9hVl26D75fK072wDG2reYKI+aJx4X6IeqxYiYAzXlz6gGJuRKqmQwSAYiy9y6vBrpwWj5QGMjEOlwkd42nw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/devtools": "0.2.1",
+        "@floating-ui/dom": "^1.6.12",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-progress": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-progress/-/react-progress-9.4.2.tgz",
+      "integrity": "sha512-ra7kKByfq+uIg330twi9aagqUkKKls35jC9Hth0k8txIvt3u9y7Qm28wZStP4EAxapJXs/4LfI+0ZwdPQguH2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.4.2",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-provider": {
+      "version": "9.22.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-provider/-/react-provider-9.22.2.tgz",
+      "integrity": "sha512-7/ZUluKMBb9sxlSi/r0n4nHcgfWW0Ph4ZkkAi8c4uFg7JSKJjR3a1Ii9Wqxs+veK9PdNzILe6EMRXj8MWje8HA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/core": "^1.16.0",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-radio": {
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-radio/-/react-radio-9.5.2.tgz",
+      "integrity": "sha512-ny+odHLH6h0bl/x0wxT1/J9k93lxQb3UMrTppDNFN4QudomHJJCAuwIzYLHrehxU0Iz6a9BGcbBXyUqEZANvNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.4.2",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-label": "^9.3.2",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-rating": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-rating/-/react-rating-9.3.2.tgz",
+      "integrity": "sha512-TsrPYNZW57A8KhBjWxTyeyb/3qt9NG8ZmBy5QB9DXS7dykj02dJXOVVOT3+vRQk4aKZ17RxXYZXfZNYoYzlAnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <19.0.0",
+        "@types/react-dom": ">=16.8.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-search": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-search/-/react-search-9.3.2.tgz",
+      "integrity": "sha512-s2tvGeVGy6jdIEo3ezhzAg1CzvsaaspXgF/x9Ykapyjs9AiG78cWJ3/HAfZY6kajq9h47eTwYEkDTEORqdvajQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-input": "^9.7.2",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-select": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-select/-/react-select-9.4.2.tgz",
+      "integrity": "sha512-ST5hoXjjN0RQMDtwlC85AKej+W+3ayx1a9v+YlkQX2lOh+6Sj3iABsETgPM01Se8YwJ4DCbkJ5B52FVxXzXuuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.4.2",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-shared-contexts": {
+      "version": "9.24.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-shared-contexts/-/react-shared-contexts-9.24.1.tgz",
+      "integrity": "sha512-gQmynczh226aiPTV8PyzpOlSX0QTOZt0DG7ok/Q53DLWqBkRqsmfMHCEKZcDnjnemizu1IzB01NiXjXtk3WKzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-theme": "^9.2.0",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-skeleton": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-skeleton/-/react-skeleton-9.4.2.tgz",
+      "integrity": "sha512-v3elD30iWnx2frIdvcZnnd8D62pWi2HmLP5JA7So/v4iJ+mAAfnvLKDzbs27rtGhO6qTptPROt5WmtnHUI8y0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.4.2",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-slider": {
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-slider/-/react-slider-9.5.2.tgz",
+      "integrity": "sha512-ZWoR+a+hLdbmjlH3WJNccH+yEjaeXVdZJT85v/OwrKIUoLdDHkCOPuW35lxuVd8slLlh7gBxRKC2aS1uP/83Iw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.4.2",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-spinbutton": {
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-spinbutton/-/react-spinbutton-9.5.2.tgz",
+      "integrity": "sha512-LKRNI2SbdiKL5u8m1DZCaamfJjlHh+a0VDbPvy6KWfORHtlUYhvbGf1CRLGHNNLtL40WgbEzZx9DeM6iv/kM/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-field": "^9.4.2",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-spinner": {
+      "version": "9.7.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-spinner/-/react-spinner-9.7.2.tgz",
+      "integrity": "sha512-+5XFzqwfDrFhK8iJ1MDdYZ0wGHeGsFR5H9Iw58JyIxcNNFNkHIGZYLpHgM15wYHzLmheS4CzWUY1IT2Ifen3oQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-label": "^9.3.2",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-swatch-picker": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-swatch-picker/-/react-swatch-picker-9.4.2.tgz",
+      "integrity": "sha512-vduek/Psaqll/bFO9XJ91YCnE+KXphOqTkYzBKf4aLYJBJys/IFi5sIrEGlaxDMpgg8BeExSHjit9vuCArGjaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-context-selector": "^9.2.4",
+        "@fluentui/react-field": "^9.4.2",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <19.0.0",
+        "@types/react-dom": ">=16.8.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-swatch-picker/node_modules/@fluentui/react-context-selector": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.2.4.tgz",
+      "integrity": "sha512-4QJjaBWoJSW+Vu6XRT0A9j3h2RGdXNUj9ur6ljdXwG13DoE69v03cDVF8GT3jiXWO3veNJntelI0BS99Qb5wzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0",
+        "scheduler": ">=0.19.0 <=0.23.0"
+      }
+    },
+    "node_modules/@fluentui/react-swatch-picker/node_modules/scheduler": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/@fluentui/react-switch": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-switch/-/react-switch-9.4.2.tgz",
+      "integrity": "sha512-u/E7UeRRUbe5RnHNdslois6eGV6AFqJpzau48EDokmyJmv9nHIjq8ckt32kRH1dNcUm0/6BsXS40Wg0dhLgS0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.4.2",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-label": "^9.3.2",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-table": {
+      "version": "9.18.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-table/-/react-table-9.18.3.tgz",
+      "integrity": "sha512-khocRe5sjHp1KDDfnw4nd6iA7tWn4y7pK10ZTPRixSWzW2mu24PSPWq9I+suMpAuIhcjZfbit4SRZd8v+JQt+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.16.2",
+        "@fluentui/react-avatar": "^9.9.3",
+        "@fluentui/react-checkbox": "^9.5.2",
+        "@fluentui/react-context-selector": "^9.2.4",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-radio": "^9.5.2",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-table/node_modules/@fluentui/react-context-selector": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.2.4.tgz",
+      "integrity": "sha512-4QJjaBWoJSW+Vu6XRT0A9j3h2RGdXNUj9ur6ljdXwG13DoE69v03cDVF8GT3jiXWO3veNJntelI0BS99Qb5wzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0",
+        "scheduler": ">=0.19.0 <=0.23.0"
+      }
+    },
+    "node_modules/@fluentui/react-table/node_modules/scheduler": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/@fluentui/react-tabs": {
+      "version": "9.9.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tabs/-/react-tabs-9.9.2.tgz",
+      "integrity": "sha512-7dOhz7NHoi4kcn0B+RcReOgGi776yy5chPborwZQOTLg/E94fGkUecj8TkCLZdEUBOTrSIPaaWRF6m4atl+UEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-context-selector": "^9.2.4",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-tabs/node_modules/@fluentui/react-context-selector": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.2.4.tgz",
+      "integrity": "sha512-4QJjaBWoJSW+Vu6XRT0A9j3h2RGdXNUj9ur6ljdXwG13DoE69v03cDVF8GT3jiXWO3veNJntelI0BS99Qb5wzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0",
+        "scheduler": ">=0.19.0 <=0.23.0"
+      }
+    },
+    "node_modules/@fluentui/react-tabs/node_modules/scheduler": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/@fluentui/react-tabster": {
+      "version": "9.26.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tabster/-/react-tabster-9.26.2.tgz",
+      "integrity": "sha512-Go9wzXjhZEcejfiw1vFqgC06p/+fPxw5woPblmiXYUDjNByCY5iTx2vNv6gf+duFZqLDITVhsA0t5P9xdDLiLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1",
+        "keyborg": "^2.6.0",
+        "tabster": "^8.5.5"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-tag-picker": {
+      "version": "9.7.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tag-picker/-/react-tag-picker-9.7.3.tgz",
+      "integrity": "sha512-IRvQ00Q8QU8ReXOB7agTsl0hc+9xMWW9wVEnkvnAxGYHWrGhq/w161+kZHO5LAVHOB7HHufKOlgNKLokKcpUUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.16.2",
+        "@fluentui/react-combobox": "^9.16.3",
+        "@fluentui/react-context-selector": "^9.2.4",
+        "@fluentui/react-field": "^9.4.2",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-portal": "^9.7.2",
+        "@fluentui/react-positioning": "^9.20.2",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-tags": "^9.7.3",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-tag-picker/node_modules/@fluentui/react-context-selector": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.2.4.tgz",
+      "integrity": "sha512-4QJjaBWoJSW+Vu6XRT0A9j3h2RGdXNUj9ur6ljdXwG13DoE69v03cDVF8GT3jiXWO3veNJntelI0BS99Qb5wzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0",
+        "scheduler": ">=0.19.0 <=0.23.0"
+      }
+    },
+    "node_modules/@fluentui/react-tag-picker/node_modules/scheduler": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/@fluentui/react-tags": {
+      "version": "9.7.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tags/-/react-tags-9.7.3.tgz",
+      "integrity": "sha512-SSzU9tpuYdU9MsWoaK2dCuNl47yT8Wm+yBJLUJ6T/mV2yrJ7nL7r9/8LsSLf3T02MKPqWp9NwV2b1Bdy7cWRJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.16.2",
+        "@fluentui/react-avatar": "^9.9.3",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-teaching-popover": {
+      "version": "9.6.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-teaching-popover/-/react-teaching-popover-9.6.3.tgz",
+      "integrity": "sha512-sorXgLYGVtP30IpAZIXVyylIW13FL3r+2DXPGBjq2Q69JM1ZBvzNaty0csx6V/Keoo1DGLF/39NpLgdVWWdikw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-aria": "^9.16.2",
+        "@fluentui/react-button": "^9.6.3",
+        "@fluentui/react-context-selector": "^9.2.4",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-popover": "^9.12.3",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <19.0.0",
+        "@types/react-dom": ">=16.8.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-teaching-popover/node_modules/@fluentui/react-context-selector": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.2.4.tgz",
+      "integrity": "sha512-4QJjaBWoJSW+Vu6XRT0A9j3h2RGdXNUj9ur6ljdXwG13DoE69v03cDVF8GT3jiXWO3veNJntelI0BS99Qb5wzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0",
+        "scheduler": ">=0.19.0 <=0.23.0"
+      }
+    },
+    "node_modules/@fluentui/react-teaching-popover/node_modules/scheduler": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/@fluentui/react-text": {
+      "version": "9.6.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-text/-/react-text-9.6.2.tgz",
+      "integrity": "sha512-gBUV3jvTdKmvXkRU2s9vsFWIBP2Ukx+BAalR+vgJM2wibVYFAgHPVDw2/Sojjl7NxzgHDAD2dZdKegQR1AScZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-textarea": {
+      "version": "9.6.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-textarea/-/react-textarea-9.6.2.tgz",
+      "integrity": "sha512-8sRTrrO0/iEVsA2OfINasG3eo5TVQ9br0vmm04zFZgtxKkEC9xtuJGLLHk3B6wbsmAST/JVl9k3xvkg1ES/Xqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.4.2",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-theme": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-theme/-/react-theme-9.2.0.tgz",
+      "integrity": "sha512-Q0zp/MY1m5RjlkcwMcjn/PQRT2T+q3bgxuxWbhgaD07V+tLzBhGROvuqbsdg4YWF/IK21zPfLhmGyifhEu0DnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/tokens": "1.0.0-alpha.22",
+        "@swc/helpers": "^0.5.1"
+      }
+    },
+    "node_modules/@fluentui/react-toast": {
+      "version": "9.6.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-toast/-/react-toast-9.6.3.tgz",
+      "integrity": "sha512-7PCmFbeQxLGTxr8pKE621C8NHZ85A25i+0FZcqHpHMmVYHJhEvefxMS7ttLD7nlfwNHW63wtTJlAFIJ43NTfrg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.16.2",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-motion": "^9.10.1",
+        "@fluentui/react-motion-components-preview": "^0.8.1",
+        "@fluentui/react-portal": "^9.7.2",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-toolbar": {
+      "version": "9.6.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-toolbar/-/react-toolbar-9.6.3.tgz",
+      "integrity": "sha512-8hlDI4f2fpqJVu94y4RyuNxq7TA3Blj3tepyCZ3ifTcXTPt/DEfAz48MF4H8xRygz7Et6klOLwCkrwWm0U+8PA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-button": "^9.6.3",
+        "@fluentui/react-context-selector": "^9.2.4",
+        "@fluentui/react-divider": "^9.4.2",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-radio": "^9.5.2",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-toolbar/node_modules/@fluentui/react-context-selector": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.2.4.tgz",
+      "integrity": "sha512-4QJjaBWoJSW+Vu6XRT0A9j3h2RGdXNUj9ur6ljdXwG13DoE69v03cDVF8GT3jiXWO3veNJntelI0BS99Qb5wzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0",
+        "scheduler": ">=0.19.0 <=0.23.0"
+      }
+    },
+    "node_modules/@fluentui/react-toolbar/node_modules/scheduler": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/@fluentui/react-tooltip": {
+      "version": "9.8.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tooltip/-/react-tooltip-9.8.2.tgz",
+      "integrity": "sha512-nqU4JqgkC50HYplmAWvNMSgemK8OFSlYqSurzGw9KAFTqddKlVjPmYochR6xzYq7Kpu1qfaCmaX/Nqz8rM30IA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-portal": "^9.7.2",
+        "@fluentui/react-positioning": "^9.20.2",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-tree": {
+      "version": "9.12.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tree/-/react-tree-9.12.3.tgz",
+      "integrity": "sha512-XZUJh7sU1EefU4Ow7tEF/KTi8GRyIToiCAAZ5uThp2lEJ8/RSAEI6m0eh8jX4JIs1bPi5sfnLWWI34Fqua0ltA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.16.2",
+        "@fluentui/react-avatar": "^9.9.3",
+        "@fluentui/react-button": "^9.6.3",
+        "@fluentui/react-checkbox": "^9.5.2",
+        "@fluentui/react-context-selector": "^9.2.4",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-motion": "^9.10.1",
+        "@fluentui/react-motion-components-preview": "^0.8.1",
+        "@fluentui/react-radio": "^9.5.2",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-tree/node_modules/@fluentui/react-context-selector": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.2.4.tgz",
+      "integrity": "sha512-4QJjaBWoJSW+Vu6XRT0A9j3h2RGdXNUj9ur6ljdXwG13DoE69v03cDVF8GT3jiXWO3veNJntelI0BS99Qb5wzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0",
+        "scheduler": ">=0.19.0 <=0.23.0"
+      }
+    },
+    "node_modules/@fluentui/react-tree/node_modules/scheduler": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/@fluentui/react-utilities": {
+      "version": "9.23.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-utilities/-/react-utilities-9.23.1.tgz",
+      "integrity": "sha512-Vzxq4To9/HhfohYaZLcmSSSjLwn3bZ6HrlHHyCtv8jA28D5HtI9Xue3Xqy+nCshMSozwBxkrI7iWj9awmyUdQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-virtualizer": {
+      "version": "9.0.0-alpha.102",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-virtualizer/-/react-virtualizer-9.0.0-alpha.102.tgz",
+      "integrity": "sha512-kt/kuAMTKTTY/00ToUlgUwUCty2HGj4Tnr+fxKRmr7Ziy5VWhi1YoNJ8vcgmxog5J90t4tS29LB0LP0KztQUVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
       }
     },
     "node_modules/@fluentui/react-window-provider": {
@@ -1748,6 +3804,15 @@
       "peerDependencies": {
         "@types/react": ">=16.8.0 <19.0.0",
         "react": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/tokens": {
+      "version": "1.0.0-alpha.22",
+      "resolved": "https://registry.npmjs.org/@fluentui/tokens/-/tokens-1.0.0-alpha.22.tgz",
+      "integrity": "sha512-i9fgYyyCWFRdUi+vQwnV6hp7wpLGK4p09B+O/f2u71GBXzPuniubPYvrIJYtl444DD6shLjYToJhQ1S6XTFwLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.1"
       }
     },
     "node_modules/@fluentui/utilities": {
@@ -2681,12 +4746,46 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.197",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.197.tgz",
       "integrity": "sha512-m1xWB3g7vJ6asIFz+2pBUbq3uGmfmln1M9SSvBe4QIFWYrRHylP73zL/3nMjDmwz8V+1xAXQDfBd6+HPW0WvDQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/embla-carousel": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
+      "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
+      "license": "MIT"
+    },
+    "node_modules/embla-carousel-autoplay": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-autoplay/-/embla-carousel-autoplay-8.6.0.tgz",
+      "integrity": "sha512-OBu5G3nwaSXkZCo1A6LTaFMZ8EpkYbwIaH+bPqdBnDGQ2fh4+NbzjXjs2SktoPNKCtflfVMc75njaDHOYXcrsA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "embla-carousel": "8.6.0"
+      }
+    },
+    "node_modules/embla-carousel-fade": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-fade/-/embla-carousel-fade-8.6.0.tgz",
+      "integrity": "sha512-qaYsx5mwCz72ZrjlsXgs1nKejSrW+UhkbOMwLgfRT7w2LtdEB03nPRI06GHuHv5ac2USvbEiX2/nAHctcDwvpg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "embla-carousel": "8.6.0"
+      }
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -3319,6 +5418,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/keyborg": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/keyborg/-/keyborg-2.6.0.tgz",
+      "integrity": "sha512-o5kvLbuTF+o326CMVYpjlaykxqYP9DphFQZ2ZpgrvBouyvOxyEB7oqe8nOLFpiV5VCtz0D3pt8gXQYWpLpBnmA==",
+      "license": "MIT"
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -3452,6 +5557,15 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -3595,6 +5709,23 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/protobufjs": {
       "version": "7.5.3",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.3.tgz",
@@ -3654,6 +5785,12 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "license": "MIT"
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -3662,6 +5799,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
       }
     },
     "node_modules/require-directory": {
@@ -3862,6 +6015,32 @@
         "node": ">=8"
       }
     },
+    "node_modules/tabster": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/tabster/-/tabster-8.5.6.tgz",
+      "integrity": "sha512-2vfrRGrx8O9BjdrtSlVA5fvpmbq5HQBRN13XFRg6LAvZ1Fr3QdBnswgT4YgFS5Bhoo5nxwgjRaRueI2Us/dv7g==",
+      "license": "MIT",
+      "dependencies": {
+        "keyborg": "2.6.0",
+        "tslib": "^2.8.1"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-linux-x64-gnu": "4.40.0"
+      }
+    },
+    "node_modules/tabster/node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.40.0.tgz",
+      "integrity": "sha512-RcDGMtqF9EFN8i2RYN2W+64CdHruJ5rPqrlYw+cgM3uOVPSsnAQps7cpjXe9be/yDp8UC7VLoCoKC8J3Kn2FkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.14",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
@@ -3943,6 +6122,27 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-disposable": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/use-disposable/-/use-disposable-1.0.4.tgz",
+      "integrity": "sha512-j83t6AMLWUyb5zwlTDqf6dP9LezM9R0yTbI/b6olmdaGtCKQUe9pgJWV6dRaaQLcozypjIEp4EmZr2DkZGKLSg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <19.0.0",
+        "@types/react-dom": ">=16.8.0 <19.0.0",
+        "react": ">=16.8.0 <19.0.0",
+        "react-dom": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/vite": {

--- a/platforma/package.json
+++ b/platforma/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@fluentui/react": "^8.123.4",
+    "@fluentui/react-components": "^9.68.2",
     "@fluentui/react-icons": "^2.0.307",
     "@types/react": "^18.3.23",
     "@types/react-dom": "^18.3.7",

--- a/platforma/src/App.jsx
+++ b/platforma/src/App.jsx
@@ -1,4 +1,6 @@
 import { initializeIcons, Stack } from '@fluentui/react';
+import { FluentProvider, webLightTheme, webDarkTheme } from '@fluentui/react-components';
+import { useState } from 'react';
 import Navbar from './components/Navbar';
 import ImageCarousel from './components/ImageCarousel';
 import Footer from './components/Footer';
@@ -6,12 +8,16 @@ import Footer from './components/Footer';
 initializeIcons();
 
 export default function App() {
+  const [isDark, setIsDark] = useState(false);
+
   return (
-    <Stack tokens={{ childrenGap: 20 }}>
-      <Navbar />
-      <ImageCarousel />
-      <Footer />
-    </Stack>
+    <FluentProvider theme={isDark ? webDarkTheme : webLightTheme}>
+      <Stack tokens={{ childrenGap: 20 }}>
+        <Navbar isDark={isDark} setIsDark={setIsDark} />
+        <ImageCarousel />
+        <Footer />
+      </Stack>
+    </FluentProvider>
   );
 }
 

--- a/platforma/src/components/Navbar.jsx
+++ b/platforma/src/components/Navbar.jsx
@@ -1,4 +1,4 @@
-import { CommandBar } from '@fluentui/react';
+import { CommandBar, Toggle } from '@fluentui/react';
 
 const navItems = [
   { key: 'home', text: 'Home', href: '#' },
@@ -12,12 +12,27 @@ const navItems = [
   { key: 'players', text: 'Players', href: '#' },
 ];
 
-export default function Navbar() {
+export default function Navbar({ isDark, setIsDark }) {
+  const farItems = [
+    {
+      key: 'themeToggle',
+      onRender: () => (
+        <Toggle
+          inlineLabel
+          label="Dark mode"
+          checked={isDark}
+          onChange={(_, checked) => setIsDark(!!checked)}
+        />
+      ),
+    },
+  ];
+
   return (
     <CommandBar
       items={navItems}
+      farItems={farItems}
       ariaLabel="Main navigation"
-      styles={{ root: { padding: '0 16px', background: '#f3f2f1' } }}
+      styles={{ root: { padding: '0 16px', background: 'var(--colorNeutralBackground1)' } }}
     />
   );
 }


### PR DESCRIPTION
## Summary
- add Fluent Provider and theme toggle
- allow switching between light and dark mode via navbar control

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68934bec095c83268444b327dda6a2cd