### PR TITLE
Add routing and navigation pages

### DIFF
--- a/platforma/package-lock.json
+++ b/platforma/package-lock.json
@@ -15,7 +15,8 @@
         "@types/react-dom": "^18.3.7",
         "firebase": "^12.0.0",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-router-dom": "^6.30.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.30.1",
@@ -4074,6 +4075,15 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -5799,6 +5809,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-transition-group": {

--- a/platforma/package.json
+++ b/platforma/package.json
@@ -26,6 +26,7 @@
     "@types/react-dom": "^18.3.7",
     "firebase": "^12.0.0",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.30.1"
   }
 }

--- a/platforma/src/App.jsx
+++ b/platforma/src/App.jsx
@@ -1,9 +1,25 @@
 import { initializeIcons, Stack } from '@fluentui/react';
 import { FluentProvider, webLightTheme, webDarkTheme } from '@fluentui/react-components';
 import { useState } from 'react';
+import { Routes, Route, Navigate } from 'react-router-dom';
 import Navbar from './components/Navbar';
-import ImageCarousel from './components/ImageCarousel';
 import Footer from './components/Footer';
+import Home from './pages/Home';
+import Article from './pages/Article';
+import News from './pages/News';
+import Game from './pages/Game';
+import Tournament from './pages/Tournament';
+import Season from './pages/Season';
+import League from './pages/League';
+import Player from './pages/Player';
+import Players from './pages/Players';
+import Team from './pages/Team';
+import Teams from './pages/Teams';
+import Venue from './pages/Venue';
+import Schedule from './pages/Schedule';
+import Standings from './pages/Standings';
+import Bracket from './pages/Bracket';
+import Calendar from './pages/Calendar';
 
 initializeIcons();
 
@@ -14,7 +30,25 @@ export default function App() {
     <FluentProvider theme={isDark ? webDarkTheme : webLightTheme}>
       <Stack tokens={{ childrenGap: 20 }}>
         <Navbar isDark={isDark} setIsDark={setIsDark} />
-        <ImageCarousel />
+        <Routes>
+          <Route path="/home" element={<Home />} />
+          <Route path="/article" element={<Article />} />
+          <Route path="/news" element={<News />} />
+          <Route path="/game" element={<Game />} />
+          <Route path="/tournament" element={<Tournament />} />
+          <Route path="/season" element={<Season />} />
+          <Route path="/league" element={<League />} />
+          <Route path="/player" element={<Player />} />
+          <Route path="/players" element={<Players />} />
+          <Route path="/team" element={<Team />} />
+          <Route path="/teams" element={<Teams />} />
+          <Route path="/venue" element={<Venue />} />
+          <Route path="/schedule" element={<Schedule />} />
+          <Route path="/standings" element={<Standings />} />
+          <Route path="/bracket" element={<Bracket />} />
+          <Route path="/calendar" element={<Calendar />} />
+          <Route path="/" element={<Navigate to="/home" replace />} />
+        </Routes>
         <Footer />
       </Stack>
     </FluentProvider>

--- a/platforma/src/components/Navbar.jsx
+++ b/platforma/src/components/Navbar.jsx
@@ -1,15 +1,23 @@
 import { Switch, Toolbar, ToolbarButton } from '@fluentui/react-components';
+import { Link } from 'react-router-dom';
 
 const navItems = [
-  { key: 'home', text: 'Home', href: '#' },
-  { key: 'news', text: 'News', href: '#' },
-  { key: 'calendar', text: 'Calendar', href: '#' },
-  { key: 'results', text: 'Results', href: '#' },
-  { key: 'schedule', text: 'Schedule', href: '#' },
-  { key: 'tables', text: 'Tables', href: '#' },
-  { key: 'stats', text: 'Stats', href: '#' },
-  { key: 'teams', text: 'Teams', href: '#' },
-  { key: 'players', text: 'Players', href: '#' },
+  { key: 'home', text: 'Home', href: '/home' },
+  { key: 'article', text: 'Article', href: '/article' },
+  { key: 'news', text: 'News', href: '/news' },
+  { key: 'game', text: 'Game', href: '/game' },
+  { key: 'tournament', text: 'Tournament', href: '/tournament' },
+  { key: 'season', text: 'Season', href: '/season' },
+  { key: 'league', text: 'League', href: '/league' },
+  { key: 'player', text: 'Player', href: '/player' },
+  { key: 'players', text: 'Players', href: '/players' },
+  { key: 'team', text: 'Team', href: '/team' },
+  { key: 'teams', text: 'Teams', href: '/teams' },
+  { key: 'venue', text: 'Venue', href: '/venue' },
+  { key: 'schedule', text: 'Schedule', href: '/schedule' },
+  { key: 'standings', text: 'Standings', href: '/standings' },
+  { key: 'bracket', text: 'Bracket', href: '/bracket' },
+  { key: 'calendar', text: 'Calendar', href: '/calendar' },
 ];
 
 export default function Navbar({ isDark, setIsDark }) {
@@ -18,8 +26,8 @@ export default function Navbar({ isDark, setIsDark }) {
       {navItems.map((item) => (
         <ToolbarButton
           key={item.key}
-          as="a"
-          href={item.href}
+          as={Link}
+          to={item.href}
           appearance="subtle"
         >
           {item.text}

--- a/platforma/src/main.jsx
+++ b/platforma/src/main.jsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './App.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>,
 )

--- a/platforma/src/pages/Article.jsx
+++ b/platforma/src/pages/Article.jsx
@@ -1,0 +1,3 @@
+export default function Article() {
+  return <h1>Article</h1>;
+}

--- a/platforma/src/pages/Bracket.jsx
+++ b/platforma/src/pages/Bracket.jsx
@@ -1,0 +1,3 @@
+export default function Bracket() {
+  return <h1>Bracket</h1>;
+}

--- a/platforma/src/pages/Calendar.jsx
+++ b/platforma/src/pages/Calendar.jsx
@@ -1,0 +1,3 @@
+export default function Calendar() {
+  return <h1>Calendar</h1>;
+}

--- a/platforma/src/pages/Game.jsx
+++ b/platforma/src/pages/Game.jsx
@@ -1,0 +1,3 @@
+export default function Game() {
+  return <h1>Game</h1>;
+}

--- a/platforma/src/pages/Home.jsx
+++ b/platforma/src/pages/Home.jsx
@@ -1,0 +1,10 @@
+import ImageCarousel from '../components/ImageCarousel';
+
+export default function Home() {
+  return (
+    <div>
+      <h1>Home</h1>
+      <ImageCarousel />
+    </div>
+  );
+}

--- a/platforma/src/pages/League.jsx
+++ b/platforma/src/pages/League.jsx
@@ -1,0 +1,3 @@
+export default function League() {
+  return <h1>League</h1>;
+}

--- a/platforma/src/pages/News.jsx
+++ b/platforma/src/pages/News.jsx
@@ -1,0 +1,3 @@
+export default function News() {
+  return <h1>News</h1>;
+}

--- a/platforma/src/pages/Player.jsx
+++ b/platforma/src/pages/Player.jsx
@@ -1,0 +1,3 @@
+export default function Player() {
+  return <h1>Player</h1>;
+}

--- a/platforma/src/pages/Players.jsx
+++ b/platforma/src/pages/Players.jsx
@@ -1,0 +1,3 @@
+export default function Players() {
+  return <h1>Players</h1>;
+}

--- a/platforma/src/pages/Schedule.jsx
+++ b/platforma/src/pages/Schedule.jsx
@@ -1,0 +1,3 @@
+export default function Schedule() {
+  return <h1>Schedule</h1>;
+}

--- a/platforma/src/pages/Season.jsx
+++ b/platforma/src/pages/Season.jsx
@@ -1,0 +1,3 @@
+export default function Season() {
+  return <h1>Season</h1>;
+}

--- a/platforma/src/pages/Standings.jsx
+++ b/platforma/src/pages/Standings.jsx
@@ -1,0 +1,3 @@
+export default function Standings() {
+  return <h1>Standings</h1>;
+}

--- a/platforma/src/pages/Team.jsx
+++ b/platforma/src/pages/Team.jsx
@@ -1,0 +1,3 @@
+export default function Team() {
+  return <h1>Team</h1>;
+}

--- a/platforma/src/pages/Teams.jsx
+++ b/platforma/src/pages/Teams.jsx
@@ -1,0 +1,3 @@
+export default function Teams() {
+  return <h1>Teams</h1>;
+}

--- a/platforma/src/pages/Tournament.jsx
+++ b/platforma/src/pages/Tournament.jsx
@@ -1,0 +1,3 @@
+export default function Tournament() {
+  return <h1>Tournament</h1>;
+}

--- a/platforma/src/pages/Venue.jsx
+++ b/platforma/src/pages/Venue.jsx
@@ -1,0 +1,3 @@
+export default function Venue() {
+  return <h1>Venue</h1>;
+}


### PR DESCRIPTION
## Summary
- expand top navigation to 16 items
- add simple page components for each nav item
- integrate React Router for navigation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893792c11488326b142cc81f6f1e93c