### PR TITLE
Add sticky footer with 3LK logo

### DIFF
--- a/platforma/src/App.jsx
+++ b/platforma/src/App.jsx
@@ -12,7 +12,7 @@ export default function App() {
 
   return (
     <FluentProvider theme={isDark ? webDarkTheme : webLightTheme}>
-      <Stack tokens={{ childrenGap: 20 }}>
+      <Stack tokens={{ childrenGap: 20 }} styles={{ root: { minHeight: '100vh' } }}>
         <Navbar isDark={isDark} setIsDark={setIsDark} />
         <ImageCarousel />
         <Footer />

--- a/platforma/src/components/Footer.jsx
+++ b/platforma/src/components/Footer.jsx
@@ -2,7 +2,24 @@ import { Stack, Text } from '@fluentui/react';
 
 export default function Footer() {
   return (
-    <Stack horizontalAlign="center" styles={{ root: { padding: 20, background: '#f3f2f1' } }}>
+    <Stack
+      horizontal
+      horizontalAlign="center"
+      verticalAlign="center"
+      tokens={{ childrenGap: 10 }}
+      styles={{
+        root: {
+          padding: 20,
+          background: '#f3f2f1',
+          marginTop: 'auto',
+        },
+      }}
+    >
+      <img
+        src="https://3lk-admin.plka.pl/media-files/league/images/LOGO_3LK_WHITE_FqTzfmx.png"
+        alt="3LK logo"
+        style={{ height: 40 }}
+      />
       <Text variant="small">© 2023 Amateur Basketball League</Text>
     </Stack>
   );


### PR DESCRIPTION
## Summary
- make footer span full width and include 3LK league logo
- ensure app layout fills viewport so footer sticks to page bottom

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689379c581e88326b5eb245cfc866228