### PR TITLE
Add Fluent UI bracket component and examples

### DIFF
--- a/platforma/src/components/bracket/TournamentBracket.jsx
+++ b/platforma/src/components/bracket/TournamentBracket.jsx
@@ -1,0 +1,55 @@
+import { Card, Text, makeStyles, shorthands } from '@fluentui/react-components';
+
+const useStyles = makeStyles({
+  bracket: {
+    display: 'flex',
+    columnGap: '24px',
+    alignItems: 'flex-start',
+  },
+  round: {
+    display: 'flex',
+    flexDirection: 'column',
+    rowGap: '12px',
+  },
+  match: {
+    width: '160px',
+    ...shorthands.padding('8px'),
+  },
+  team: {
+    display: 'flex',
+    justifyContent: 'space-between',
+  },
+});
+
+function Match({ sides }) {
+  const styles = useStyles();
+  return (
+    <Card className={styles.match} appearance="filled">
+      {sides.map((side, index) => (
+        <div key={index} className={styles.team}>
+          <Text>{side.team}</Text>
+          {side.score !== undefined && (
+            <Text weight="semibold">{side.score}</Text>
+          )}
+        </div>
+      ))}
+    </Card>
+  );
+}
+
+export default function TournamentBracket({ rounds }) {
+  const styles = useStyles();
+  return (
+    <div className={styles.bracket}>
+      {rounds.map((round, rIndex) => (
+        <div key={rIndex} className={styles.round}>
+          <Text weight="semibold">{round.name}</Text>
+          {round.matches.map((match) => (
+            <Match key={match.id} sides={match.sides} />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+

--- a/platforma/src/pages/Bracket.jsx
+++ b/platforma/src/pages/Bracket.jsx
@@ -1,3 +1,72 @@
+import { FluentProvider, Text, webDarkTheme, webLightTheme } from '@fluentui/react-components';
+import TournamentBracket from '../components/bracket/TournamentBracket';
+
+const lightExample = {
+  rounds: [
+    {
+      name: 'Semifinals',
+      matches: [
+        { id: 1, sides: [{ team: 'Lions', score: 80 }, { team: 'Tigers', score: 75 }] },
+        { id: 2, sides: [{ team: 'Bears', score: 68 }, { team: 'Hawks', score: 70 }] },
+      ],
+    },
+    {
+      name: 'Final',
+      matches: [
+        { id: 3, sides: [{ team: 'Lions', score: 88 }, { team: 'Hawks', score: 90 }] },
+      ],
+    },
+  ],
+};
+
+const darkExample = {
+  rounds: [
+    {
+      name: 'Quarterfinals',
+      matches: [
+        { id: 1, sides: [{ team: 'Alpha', score: 1 }, { team: 'Bravo', score: 0 }] },
+        { id: 2, sides: [{ team: 'Charlie', score: 1 }, { team: 'Delta', score: 0 }] },
+        { id: 3, sides: [{ team: 'Echo', score: 1 }, { team: 'Foxtrot', score: 0 }] },
+        { id: 4, sides: [{ team: 'Golf', score: 1 }, { team: 'Hotel', score: 0 }] },
+      ],
+    },
+    {
+      name: 'Semifinals',
+      matches: [
+        { id: 5, sides: [{ team: 'Alpha', score: 1 }, { team: 'Charlie', score: 0 }] },
+        { id: 6, sides: [{ team: 'Echo', score: 1 }, { team: 'Golf', score: 0 }] },
+      ],
+    },
+    {
+      name: 'Final',
+      matches: [
+        { id: 7, sides: [{ team: 'Alpha', score: 1 }, { team: 'Echo', score: 0 }] },
+      ],
+    },
+  ],
+};
+
 export default function Bracket() {
-  return <h1>Bracket</h1>;
+  return (
+    <div style={{ padding: 16 }}>
+      <Text as="h1" size={800} block>
+        Bracket
+      </Text>
+
+      <Text as="h2" size={500} block>
+        Light theme
+      </Text>
+      <FluentProvider theme={webLightTheme} style={{ padding: 16 }}>
+        <TournamentBracket rounds={lightExample.rounds} />
+      </FluentProvider>
+
+      <Text as="h2" size={500} block style={{ marginTop: 32 }}>
+        Dark theme
+      </Text>
+      <FluentProvider theme={webDarkTheme} style={{ padding: 16 }}>
+        <TournamentBracket rounds={darkExample.rounds} />
+      </FluentProvider>
+    </div>
+  );
 }
+


### PR DESCRIPTION
## Summary
- implement TournamentBracket component with Fluent UI Card/Text
- show light and dark themed bracket examples on Bracket page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68937e3ee708832696836c8cb1b49f8e