### PR TITLE
Add Fluent UI bracket component and examples

### DIFF
--- a/platforma/src/components/bracket/TournamentBracket.jsx
+++ b/platforma/src/components/bracket/TournamentBracket.jsx
@@ -1,0 +1,55 @@
+import { Card, Text, makeStyles, shorthands } from '@fluentui/react-components';
+
+const useStyles = makeStyles({
+  bracket: {
+    display: 'flex',
+    columnGap: '24px',
+    alignItems: 'flex-start',
+  },
+  round: {
+    display: 'flex',
+    flexDirection: 'column',
+    rowGap: '12px',
+  },
+  match: {
+    width: '160px',
+    ...shorthands.padding('8px'),
+  },
+  team: {
+    display: 'flex',
+    justifyContent: 'space-between',
+  },
+});
+
+function Match({ sides }) {
+  const styles = useStyles();
+  return (
+    <Card className={styles.match} appearance="filled">
+      {sides.map((side, index) => (
+        <div key={index} className={styles.team}>
+          <Text>{side.team}</Text>
+          {side.score !== undefined && (
+            <Text weight="semibold">{side.score}</Text>
+          )}
+        </div>
+      ))}
+    </Card>
+  );
+}
+
+export default function TournamentBracket({ rounds }) {
+  const styles = useStyles();
+  return (
+    <div className={styles.bracket}>
+      {rounds.map((round, rIndex) => (
+        <div key={rIndex} className={styles.round}>
+          <Text weight="semibold">{round.name}</Text>
+          {round.matches.map((match) => (
+            <Match key={match.id} sides={match.sides} />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+

--- a/platforma/src/components/bracket/TournamentBracket.jsx
+++ b/platforma/src/components/bracket/TournamentBracket.jsx
@@ -1,54 +1,143 @@
-import { Card, Text, makeStyles, shorthands } from '@fluentui/react-components';
+import {
+  Card,
+  Text,
+  makeStyles,
+  shorthands,
+  tokens,
+} from '@fluentui/react-components';
+import { CheckmarkCircle20Regular } from '@fluentui/react-icons';
 
 const useStyles = makeStyles({
   bracket: {
     display: 'flex',
-    columnGap: '24px',
+    columnGap: '32px',
     alignItems: 'flex-start',
   },
   round: {
     display: 'flex',
     flexDirection: 'column',
-    rowGap: '12px',
   },
   match: {
     width: '160px',
+    height: '48px',
+    position: 'relative',
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
     ...shorthands.padding('8px'),
   },
   team: {
     display: 'flex',
     justifyContent: 'space-between',
+    alignItems: 'center',
+    columnGap: '4px',
+  },
+  score: {
+    display: 'flex',
+    alignItems: 'center',
+    columnGap: '4px',
+  },
+  lineRight: {
+    position: 'absolute',
+    top: '50%',
+    right: '-24px',
+    width: '24px',
+    height: '2px',
+    backgroundColor: tokens.colorNeutralStroke1,
+  },
+  lineLeft: {
+    position: 'absolute',
+    top: '50%',
+    left: '-24px',
+    width: '24px',
+    height: '2px',
+    backgroundColor: tokens.colorNeutralStroke1,
+  },
+  lineVertical: {
+    position: 'absolute',
+    right: '-24px',
+    width: '2px',
+    backgroundColor: tokens.colorNeutralStroke1,
   },
 });
 
-function Match({ sides }) {
+function Match({
+  sides,
+  hasPrev,
+  hasNext,
+  index,
+  connectorHeight,
+  style,
+}) {
   const styles = useStyles();
+  const scores = sides.map((s) => (s.score ?? 0));
+  const winnerIndex = scores[0] >= scores[1] ? 0 : 1;
   return (
-    <Card className={styles.match} appearance="filled">
-      {sides.map((side, index) => (
-        <div key={index} className={styles.team}>
-          <Text>{side.team}</Text>
-          {side.score !== undefined && (
-            <Text weight="semibold">{side.score}</Text>
-          )}
+    <Card className={styles.match} appearance="filled" style={style}>
+      {sides.map((side, i) => (
+        <div key={i} className={styles.team}>
+          <Text weight={winnerIndex === i ? 'semibold' : 'regular'}>{side.team}</Text>
+          <div className={styles.score}>
+            {side.score !== undefined && (
+              <Text weight={winnerIndex === i ? 'semibold' : 'regular'}>
+                {side.score}
+              </Text>
+            )}
+            {winnerIndex === i && (
+              <CheckmarkCircle20Regular color={tokens.colorStatusSuccessForeground1} />
+            )}
+          </div>
         </div>
       ))}
+      {hasNext && <div className={styles.lineRight} />}
+      {hasPrev && <div className={styles.lineLeft} />}
+      {hasNext && index % 2 === 0 && (
+        <div
+          className={styles.lineVertical}
+          style={{ top: '50%', height: connectorHeight }}
+        />
+      )}
     </Card>
   );
 }
 
 export default function TournamentBracket({ rounds }) {
   const styles = useStyles();
+  const matchSpacing = 72; // match height + gap
   return (
     <div className={styles.bracket}>
-      {rounds.map((round, rIndex) => (
-        <div key={rIndex} className={styles.round}>
-          <Text weight="semibold">{round.name}</Text>
-          {round.matches.map((match) => (
-            <Match key={match.id} sides={match.sides} />
-          ))}
-        </div>
-      ))}
+      {rounds.map((round, rIndex) => {
+        const isThirdPlace = round.name === 'Third Place';
+        return (
+          <div key={rIndex} className={styles.round}>
+            <Text weight="semibold">{round.name}</Text>
+            {round.matches.map((match, mIndex) => {
+              const spacing = matchSpacing * Math.pow(2, rIndex);
+              let marginTop;
+              if (isThirdPlace) {
+                marginTop = mIndex === 0 ? 0 : spacing - 48;
+              } else {
+                const offset = rIndex === 0 ? 0 : spacing / 2 - 24;
+                marginTop = mIndex === 0 ? offset : spacing - 48;
+              }
+              const hasPrev = !isThirdPlace && rIndex > 0;
+              const nextIsThird = rounds[rIndex + 1]?.name === 'Third Place';
+              const hasNext = !isThirdPlace && !nextIsThird && rIndex < rounds.length - 1;
+              return (
+                <Match
+                  key={match.id}
+                  sides={match.sides}
+                  hasPrev={hasPrev}
+                  hasNext={hasNext}
+                  index={mIndex}
+                  connectorHeight={spacing}
+                  style={{ marginTop }}
+                />
+              );
+            })}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/platforma/src/pages/Bracket.jsx
+++ b/platforma/src/pages/Bracket.jsx
@@ -1,3 +1,72 @@
+import { FluentProvider, Text, webDarkTheme, webLightTheme } from '@fluentui/react-components';
+import TournamentBracket from '../components/bracket/TournamentBracket';
+
+const lightExample = {
+  rounds: [
+    {
+      name: 'Semifinals',
+      matches: [
+        { id: 1, sides: [{ team: 'Lions', score: 80 }, { team: 'Tigers', score: 75 }] },
+        { id: 2, sides: [{ team: 'Bears', score: 68 }, { team: 'Hawks', score: 70 }] },
+      ],
+    },
+    {
+      name: 'Final',
+      matches: [
+        { id: 3, sides: [{ team: 'Lions', score: 88 }, { team: 'Hawks', score: 90 }] },
+      ],
+    },
+  ],
+};
+
+const darkExample = {
+  rounds: [
+    {
+      name: 'Quarterfinals',
+      matches: [
+        { id: 1, sides: [{ team: 'Alpha', score: 1 }, { team: 'Bravo', score: 0 }] },
+        { id: 2, sides: [{ team: 'Charlie', score: 1 }, { team: 'Delta', score: 0 }] },
+        { id: 3, sides: [{ team: 'Echo', score: 1 }, { team: 'Foxtrot', score: 0 }] },
+        { id: 4, sides: [{ team: 'Golf', score: 1 }, { team: 'Hotel', score: 0 }] },
+      ],
+    },
+    {
+      name: 'Semifinals',
+      matches: [
+        { id: 5, sides: [{ team: 'Alpha', score: 1 }, { team: 'Charlie', score: 0 }] },
+        { id: 6, sides: [{ team: 'Echo', score: 1 }, { team: 'Golf', score: 0 }] },
+      ],
+    },
+    {
+      name: 'Final',
+      matches: [
+        { id: 7, sides: [{ team: 'Alpha', score: 1 }, { team: 'Echo', score: 0 }] },
+      ],
+    },
+  ],
+};
+
 export default function Bracket() {
-  return <h1>Bracket</h1>;
+  return (
+    <div style={{ padding: 16 }}>
+      <Text as="h1" size={800} block>
+        Bracket
+      </Text>
+
+      <Text as="h2" size={500} block>
+        Light theme
+      </Text>
+      <FluentProvider theme={webLightTheme} style={{ padding: 16 }}>
+        <TournamentBracket rounds={lightExample.rounds} />
+      </FluentProvider>
+
+      <Text as="h2" size={500} block style={{ marginTop: 32 }}>
+        Dark theme
+      </Text>
+      <FluentProvider theme={webDarkTheme} style={{ padding: 16 }}>
+        <TournamentBracket rounds={darkExample.rounds} />
+      </FluentProvider>
+    </div>
+  );
 }
+


### PR DESCRIPTION
## Summary
- implement TournamentBracket component with Fluent UI Card/Text
- show light and dark themed bracket examples on Bracket page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68937e3ee708832696836c8cb1b49f8e