### PR TITLE
Add Venue component with map embed

### DIFF
--- a/platforma/src/components/Venue.jsx
+++ b/platforma/src/components/Venue.jsx
@@ -1,0 +1,28 @@
+import { Stack, Image, Text } from '@fluentui/react';
+
+export default function Venue({ name, image, address, description, location }) {
+  const mapSrc = `https://www.google.com/maps?q=${encodeURIComponent(location || address)}&output=embed`;
+
+  return (
+    <Stack tokens={{ childrenGap: 20 }} styles={{ root: { maxWidth: 800, margin: '0 auto' } }}>
+      {image && (
+        <Image src={image} alt={name} styles={{ root: { width: '100%', height: 'auto' } }} />
+      )}
+      <Stack tokens={{ childrenGap: 8 }}>
+        <Text variant="xxLarge">{name}</Text>
+        <Text>{address}</Text>
+        <Text>{description}</Text>
+      </Stack>
+      <iframe
+        title={`${name} location`}
+        src={mapSrc}
+        width="100%"
+        height="300"
+        style={{ border: 0 }}
+        allowFullScreen=""
+        loading="lazy"
+        referrerPolicy="no-referrer-when-downgrade"
+      />
+    </Stack>
+  );
+}

--- a/platforma/src/pages/Venue.jsx
+++ b/platforma/src/pages/Venue.jsx
@@ -3,11 +3,11 @@ import VenueComponent from '../components/Venue';
 export default function Venue() {
   return (
     <VenueComponent
-      name="Sample Arena"
+      name="Mitch Richmond Arena"
       image="https://placehold.co/800x400"
-      address="123 Main St, City"
-      description="Home court for the sample team."
-      location="123 Main St, City"
+      address="Kazimierza Górskiego 10, 81-304 Gdynia, Poland"
+      description="Boisko nr 2 na kortach Arki"
+      location="Kazimierza Górskiego 10, 81-304 Gdynia, Poland"
     />
   );
 }

--- a/platforma/src/pages/Venue.jsx
+++ b/platforma/src/pages/Venue.jsx
@@ -1,3 +1,13 @@
+import VenueComponent from '../components/Venue';
+
 export default function Venue() {
-  return <h1>Venue</h1>;
+  return (
+    <VenueComponent
+      name="Sample Arena"
+      image="https://placehold.co/800x400"
+      address="123 Main St, City"
+      description="Home court for the sample team."
+      location="123 Main St, City"
+    />
+  );
 }


### PR DESCRIPTION
## Summary
- add reusable `Venue` component to display venue details with map
- render `Venue` component on venue page with sample data

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893810940b883268332e10f2f4d3e0a