### PR TITLE
Fix top navbar routing

### DIFF
--- a/platforma/src/App.jsx
+++ b/platforma/src/App.jsx
@@ -31,7 +31,8 @@ export default function App() {
       <Stack tokens={{ childrenGap: 20 }} styles={{ root: { minHeight: '100vh' } }}>
         <Navbar isDark={isDark} setIsDark={setIsDark} />
         <Routes>
-          <Route path="/home" element={<Home />} />
+          <Route path="/" element={<Home />} />
+          <Route path="/home" element={<Navigate to="/" replace />} />
           <Route path="/article" element={<Article />} />
           <Route path="/news" element={<News />} />
           <Route path="/game" element={<Game />} />
@@ -47,7 +48,6 @@ export default function App() {
           <Route path="/standings" element={<Standings />} />
           <Route path="/bracket" element={<Bracket />} />
           <Route path="/calendar" element={<Calendar />} />
-          <Route path="/" element={<Navigate to="/home" replace />} />
         </Routes>
         <Footer />
       </Stack>

--- a/platforma/src/components/Navbar.jsx
+++ b/platforma/src/components/Navbar.jsx
@@ -2,7 +2,7 @@ import { Switch, Toolbar, ToolbarButton } from '@fluentui/react-components';
 import { Link } from 'react-router-dom';
 
 const navItems = [
-  { key: 'home', text: 'Home', href: '/home' },
+  { key: 'home', text: 'Home', href: '/' },
   { key: 'article', text: 'Article', href: '/article' },
   { key: 'news', text: 'News', href: '/news' },
   { key: 'game', text: 'Game', href: '/game' },


### PR DESCRIPTION
## Summary
- route home link to root path
- handle legacy /home path by redirecting to root

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689381c42be88326849831b29d37d6e7