### PR TITLE
Fix navbar items routing to same page

### DIFF
--- a/platforma/src/components/Navbar.jsx
+++ b/platforma/src/components/Navbar.jsx
@@ -2,36 +2,31 @@ import { Switch, Toolbar, ToolbarButton } from '@fluentui/react-components';
 import { Link } from 'react-router-dom';
 
 const navItems = [
-  { key: 'home', text: 'Home', href: '/' },
-  { key: 'article', text: 'Article', href: '/article' },
-  { key: 'news', text: 'News', href: '/news' },
-  { key: 'game', text: 'Game', href: '/game' },
-  { key: 'tournament', text: 'Tournament', href: '/tournament' },
-  { key: 'season', text: 'Season', href: '/season' },
-  { key: 'league', text: 'League', href: '/league' },
-  { key: 'player', text: 'Player', href: '/player' },
-  { key: 'players', text: 'Players', href: '/players' },
-  { key: 'team', text: 'Team', href: '/team' },
-  { key: 'teams', text: 'Teams', href: '/teams' },
-  { key: 'venue', text: 'Venue', href: '/venue' },
-  { key: 'schedule', text: 'Schedule', href: '/schedule' },
-  { key: 'standings', text: 'Standings', href: '/standings' },
-  { key: 'bracket', text: 'Bracket', href: '/bracket' },
-  { key: 'calendar', text: 'Calendar', href: '/calendar' },
+  { key: 'home', text: 'Home', to: '/' },
+  { key: 'article', text: 'Article', to: '/article' },
+  { key: 'news', text: 'News', to: '/news' },
+  { key: 'game', text: 'Game', to: '/game' },
+  { key: 'tournament', text: 'Tournament', to: '/tournament' },
+  { key: 'season', text: 'Season', to: '/season' },
+  { key: 'league', text: 'League', to: '/league' },
+  { key: 'player', text: 'Player', to: '/player' },
+  { key: 'players', text: 'Players', to: '/players' },
+  { key: 'team', text: 'Team', to: '/team' },
+  { key: 'teams', text: 'Teams', to: '/teams' },
+  { key: 'venue', text: 'Venue', to: '/venue' },
+  { key: 'schedule', text: 'Schedule', to: '/schedule' },
+  { key: 'standings', text: 'Standings', to: '/standings' },
+  { key: 'bracket', text: 'Bracket', to: '/bracket' },
+  { key: 'calendar', text: 'Calendar', to: '/calendar' },
 ];
 
 export default function Navbar({ isDark, setIsDark }) {
   return (
     <Toolbar style={{ padding: '0 16px', background: 'var(--colorNeutralBackground1)' }}>
       {navItems.map((item) => (
-        <ToolbarButton
-          key={item.key}
-          as={Link}
-          to={item.href}
-          appearance="subtle"
-        >
-          {item.text}
-        </ToolbarButton>
+        <Link key={item.key} to={item.to} style={{ textDecoration: 'none' }}>
+          <ToolbarButton appearance="subtle">{item.text}</ToolbarButton>
+        </Link>
       ))}
       <div style={{ marginLeft: 'auto' }}>
         <Switch


### PR DESCRIPTION
## Summary
- Ensure each navigation item links to its own route by wrapping Fluent UI toolbar buttons in React Router `Link`
- Replace `href` with `to` in navbar item definitions for clarity

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893845ab9288326a9812994c5922b9e