### PR TITLE
feat: customize brand themes

### DIFF
--- a/platforma/src/App.jsx
+++ b/platforma/src/App.jsx
@@ -1,5 +1,6 @@
 import { initializeIcons, Stack } from '@fluentui/react';
-import { FluentProvider, webLightTheme, webDarkTheme } from '@fluentui/react-components';
+import { FluentProvider } from '@fluentui/react-components';
+import { lightTheme, darkTheme } from './theme';
 import { useState } from 'react';
 import { Routes, Route, Navigate } from 'react-router-dom';
 import Navbar from './components/Navbar';
@@ -27,7 +28,7 @@ export default function App() {
   const [isDark, setIsDark] = useState(false);
 
   return (
-    <FluentProvider theme={isDark ? webDarkTheme : webLightTheme}>
+    <FluentProvider theme={isDark ? darkTheme : lightTheme}>
       <Stack tokens={{ childrenGap: 20 }} styles={{ root: { minHeight: '100vh' } }}>
         <Navbar isDark={isDark} setIsDark={setIsDark} />
         <Routes>

--- a/platforma/src/theme.js
+++ b/platforma/src/theme.js
@@ -1,0 +1,32 @@
+import { createLightTheme, createDarkTheme } from '@fluentui/react-components';
+
+const brand3LK = {
+  10: '#020206',
+  20: '#121626',
+  30: '#182444',
+  40: '#1B2F5E',
+  50: '#1D3B78',
+  60: '#28478C',
+  70: '#3C5495',
+  80: '#4F619E',
+  90: '#606FA7',
+  100: '#707DB0',
+  110: '#818BB9',
+  120: '#9199C2',
+  130: '#A2A8CB',
+  140: '#B2B7D5',
+  150: '#C2C6DE',
+  160: '#D3D6E7',
+};
+
+export const lightTheme = {
+  ...createLightTheme(brand3LK),
+};
+
+export const darkTheme = {
+  ...createDarkTheme(brand3LK),
+};
+
+darkTheme.colorBrandForeground1 = brand3LK[110];
+darkTheme.colorBrandForeground2 = brand3LK[120];
+


### PR DESCRIPTION
## Summary
- add 3LK brand palette and create themed light/dark variants
- swap app provider to use new themes for light/dark mode

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6893936d0c7c8326ac400d1d379b7493