### PR TITLE
fix: correct bracket winner when score undefined

### DIFF
--- a/platforma/src/components/bracket/TournamentBracket.jsx
+++ b/platforma/src/components/bracket/TournamentBracket.jsx
@@ -89,8 +89,14 @@ function Match({
   const { theme } = useFluent();
   const isDark = theme.colorNeutralForeground1 === '#ffffff';
   const connectorColor = isDark ? '#fff' : '#000';
-  const scores = sides.map((s) => (s.score ?? 0));
-  const winnerIndex = scores[0] >= scores[1] ? 0 : 1;
+  const winnerIndex =
+    sides[0].score === undefined
+      ? 1
+      : sides[1].score === undefined
+        ? 0
+        : sides[0].score >= sides[1].score
+          ? 0
+          : 1;
   return (
     <Card className={styles.match} appearance="filled" style={style}>
       {sides.map((side, i) => {


### PR DESCRIPTION
## Summary
- ensure bracket highlights the correct winner when a side has no score

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6893996eccf08326872c6b9b21e32ae7