### PR TITLE
Refine venue layout and add shadows

### DIFF
--- a/platforma/src/components/Venue.jsx
+++ b/platforma/src/components/Venue.jsx
@@ -1,31 +1,37 @@
 import { Stack, Image } from '@fluentui/react';
-import { Text } from '@fluentui/react-components';
+import { Text, tokens } from '@fluentui/react-components';
 
 export default function Venue({ name, image, address, description, location }) {
   const mapSrc = `https://www.google.com/maps?q=${encodeURIComponent(location || address)}&output=embed`;
 
   return (
     <Stack tokens={{ childrenGap: 20 }} styles={{ root: { maxWidth: 800, margin: '0 auto' } }}>
+      <Text as="h1" size={800} block style={{ color: 'var(--colorNeutralForeground1)' }}>
+        {name}
+      </Text>
       {image && (
-        <Image src={image} alt={name} styles={{ root: { width: '100%', height: 'auto' } }} />
+        <Image
+          src={image}
+          alt={name}
+          styles={{ root: { width: '100%', height: 'auto', boxShadow: tokens.shadow4 } }}
+        />
       )}
-      <Stack tokens={{ childrenGap: 8 }}>
-        <Text variant="xxLarge" style={{ color: 'var(--colorNeutralForeground1)' }}>
-          {name}
-        </Text>
-        <Text style={{ color: 'var(--colorNeutralForeground1)' }}>{address}</Text>
+      {description && (
         <Text style={{ color: 'var(--colorNeutralForeground1)' }}>{description}</Text>
-      </Stack>
+      )}
       <iframe
         title={`${name} location`}
         src={mapSrc}
         width="100%"
         height="300"
-        style={{ border: 0 }}
+        style={{ border: 0, boxShadow: tokens.shadow4 }}
         allowFullScreen=""
         loading="lazy"
         referrerPolicy="no-referrer-when-downgrade"
       />
+      {location && (
+        <Text style={{ color: 'var(--colorNeutralForeground1)' }}>{location}</Text>
+      )}
     </Stack>
   );
 }


### PR DESCRIPTION
## Summary
- display venue name as large title and reorder details
- add Fluent UI shadow4 to venue image and map
- show venue location after map

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893a368aa588326aea4cb9d0b78c2c3