### PR TITLE
style: update footer background to colorNeutralForeground2BrandHover

### DIFF
--- a/platforma/src/components/Footer.jsx
+++ b/platforma/src/components/Footer.jsx
@@ -5,7 +5,7 @@ export default function Footer() {
     <div
       style={{
         padding: 20,
-        background: 'var(--colorNeutralBackground1)',
+        background: 'var(--colorNeutralForeground2BrandHover)',
         marginTop: 'auto',
         display: 'flex',
         alignItems: 'center',


### PR DESCRIPTION
## Summary
- use Fluent `colorNeutralForeground2BrandHover` for footer background

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893a3af20a083269f39524b9cef37bd