### PR TITLE
Add player detail page with Firebase data

### DIFF
--- a/platforma/src/App.jsx
+++ b/platforma/src/App.jsx
@@ -40,7 +40,7 @@ export default function App() {
           <Route path="/tournament" element={<Tournament />} />
           <Route path="/season" element={<Season />} />
           <Route path="/league" element={<League />} />
-          <Route path="/player" element={<Player />} />
+          <Route path="/player/:playerId" element={<Player />} />
           <Route path="/players" element={<Players />} />
           <Route path="/team" element={<Team />} />
           <Route path="/teams" element={<Teams />} />

--- a/platforma/src/components/bracket/TournamentBracket.jsx
+++ b/platforma/src/components/bracket/TournamentBracket.jsx
@@ -5,7 +5,6 @@ import {
   shorthands,
   tokens,
   mergeClasses,
-  useFluent,
 } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
@@ -93,8 +92,7 @@ function Match({
   style,
 }) {
   const styles = useStyles();
-  const { theme } = useFluent();
-  const connectorColor = tokens.colorNeutralForeground3Hover; //isDark ? '#fff' : '#000';
+  const connectorColor = tokens.colorNeutralForeground3Hover;
   const winnerIndex =
     sides[0].score === undefined
       ? 1

--- a/platforma/src/firebase.js
+++ b/platforma/src/firebase.js
@@ -1,6 +1,6 @@
 // Import the functions you need from the SDKs you need
-import { initializeApp } from "firebase/app";
-import { getFirestore } from "firebase/firestore";
+import { initializeApp, getApps, getApp } from 'firebase/app';
+import { getFirestore } from 'firebase/firestore';
 // TODO: Add SDKs for Firebase products that you want to use
 // https://firebase.google.com/docs/web/setup#available-libraries
 
@@ -13,12 +13,11 @@ const firebaseConfig = {
   storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET,
   messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
   appId: import.meta.env.VITE_FIREBASE_APP_ID,
-  measurementId: import.meta.env.VITE_FIREBASE_MEASURMENT_ID
+  measurementId: import.meta.env.VITE_FIREBASE_MEASUREMENT_ID,
 };
 
-// Initialize Firebase
-const app = initializeApp(firebaseConfig);
+// Initialize Firebase only once in the application
+const app = getApps().length ? getApp() : initializeApp(firebaseConfig);
 const db = getFirestore(app);
-
 
 export { db };

--- a/platforma/src/pages/Player.jsx
+++ b/platforma/src/pages/Player.jsx
@@ -10,38 +10,38 @@ export default function Player() {
   const [error, setError] = useState(null);
 
   useEffect(() => {
-    async function fetchPlayer() {
-      try {
-        const playerRef = doc(db, 'players', playerId);
-        const snapshot = await getDoc(playerRef);
+    if (!playerId) {
+      setError('No player specified');
+      setLoading(false);
+      return;
+    }
+
+    const playerRef = doc(db, 'players', playerId);
+    getDoc(playerRef)
+      .then((snapshot) => {
         if (snapshot.exists()) {
-          setPlayer(snapshot.data());
+          setPlayer({ id: snapshot.id, ...snapshot.data() });
         } else {
           setError('Player not found');
         }
-      } catch (error) {
-        console.error(error);
+      })
+      .catch((err) => {
+        console.error(err);
         setError('Failed to load player');
-      } finally {
-        setLoading(false);
-      }
-    }
-
-    if (playerId) {
-      fetchPlayer();
-    } else {
-      setError('No player specified');
-      setLoading(false);
-    }
+      })
+      .finally(() => setLoading(false));
   }, [playerId]);
 
   if (loading) return <p>Loading player...</p>;
   if (error) return <p>{error}</p>;
+  if (!player) return null;
 
   return (
     <div>
       <h1>{player.name}</h1>
-      <pre>{JSON.stringify(player, null, 2)}</pre>
+      {player.team && <p>Team: {player.team}</p>}
+      {player.position && <p>Position: {player.position}</p>}
+      {player.number && <p>Number: {player.number}</p>}
     </div>
   );
 }

--- a/platforma/src/pages/Player.jsx
+++ b/platforma/src/pages/Player.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { doc, getDoc } from 'firebase/firestore';
+import { doc, onSnapshot } from 'firebase/firestore';
 import { db } from '../firebase';
 
 export default function Player() {
@@ -17,19 +17,26 @@ export default function Player() {
     }
 
     const playerRef = doc(db, 'players', playerId);
-    getDoc(playerRef)
-      .then((snapshot) => {
+    const unsubscribe = onSnapshot(
+      playerRef,
+      (snapshot) => {
         if (snapshot.exists()) {
           setPlayer({ id: snapshot.id, ...snapshot.data() });
+          setError(null);
         } else {
           setError('Player not found');
+          setPlayer(null);
         }
-      })
-      .catch((err) => {
+        setLoading(false);
+      },
+      (err) => {
         console.error(err);
         setError('Failed to load player');
-      })
-      .finally(() => setLoading(false));
+        setLoading(false);
+      }
+    );
+
+    return () => unsubscribe();
   }, [playerId]);
 
   if (loading) return <p>Loading player...</p>;

--- a/platforma/src/pages/Player.jsx
+++ b/platforma/src/pages/Player.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { doc, onSnapshot } from 'firebase/firestore';
+import { doc, getDoc } from 'firebase/firestore';
 import { db } from '../firebase';
 
 export default function Player() {
@@ -16,10 +16,9 @@ export default function Player() {
       return;
     }
 
-    const playerRef = doc(db, 'players', playerId);
-    const unsubscribe = onSnapshot(
-      playerRef,
-      (snapshot) => {
+    async function fetchPlayer() {
+      try {
+        const snapshot = await getDoc(doc(db, 'players', playerId));
         if (snapshot.exists()) {
           setPlayer({ id: snapshot.id, ...snapshot.data() });
           setError(null);
@@ -27,16 +26,15 @@ export default function Player() {
           setError('Player not found');
           setPlayer(null);
         }
-        setLoading(false);
-      },
-      (err) => {
+      } catch (err) {
         console.error(err);
         setError('Failed to load player');
+      } finally {
         setLoading(false);
       }
-    );
+    }
 
-    return () => unsubscribe();
+    fetchPlayer();
   }, [playerId]);
 
   if (loading) return <p>Loading player...</p>;

--- a/platforma/src/pages/Player.jsx
+++ b/platforma/src/pages/Player.jsx
@@ -1,3 +1,47 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { doc, getDoc } from 'firebase/firestore';
+import { db } from '../firebase';
+
 export default function Player() {
-  return <h1>Player</h1>;
+  const { playerId } = useParams();
+  const [player, setPlayer] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    async function fetchPlayer() {
+      try {
+        const playerRef = doc(db, 'players', playerId);
+        const snapshot = await getDoc(playerRef);
+        if (snapshot.exists()) {
+          setPlayer(snapshot.data());
+        } else {
+          setError('Player not found');
+        }
+      } catch (error) {
+        console.error(error);
+        setError('Failed to load player');
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    if (playerId) {
+      fetchPlayer();
+    } else {
+      setError('No player specified');
+      setLoading(false);
+    }
+  }, [playerId]);
+
+  if (loading) return <p>Loading player...</p>;
+  if (error) return <p>{error}</p>;
+
+  return (
+    <div>
+      <h1>{player.name}</h1>
+      <pre>{JSON.stringify(player, null, 2)}</pre>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- add dynamic player detail page that loads data from Firestore
- wire route `/player/:playerId` to the detail page
- clean up unused variable in tournament bracket component

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e179f8ae883268df25b9194180a62