### PR TITLE
Load news articles from Firebase

### DIFF
--- a/platforma/src/components/bracket/TournamentBracket.jsx
+++ b/platforma/src/components/bracket/TournamentBracket.jsx
@@ -5,7 +5,6 @@ import {
   shorthands,
   tokens,
   mergeClasses,
-  useFluent,
 } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
@@ -93,7 +92,6 @@ function Match({
   style,
 }) {
   const styles = useStyles();
-  const { theme } = useFluent();
   const connectorColor = tokens.colorNeutralForeground3Hover; //isDark ? '#fff' : '#000';
   const winnerIndex =
     sides[0].score === undefined

--- a/platforma/src/pages/News.jsx
+++ b/platforma/src/pages/News.jsx
@@ -1,3 +1,40 @@
+import { useEffect, useState } from 'react';
+import { collection, getDocs } from 'firebase/firestore';
+import { db } from '../firebase';
+
 export default function News() {
-  return <h1>News</h1>;
+  const [articles, setArticles] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchArticles = async () => {
+      try {
+        const querySnapshot = await getDocs(collection(db, 'news'));
+        const items = querySnapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
+        setArticles(items);
+      } catch (error) {
+        console.error('Error loading news', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchArticles();
+  }, []);
+
+  if (loading) {
+    return <h1>Loading news...</h1>;
+  }
+
+  return (
+    <div>
+      <h1>News</h1>
+      <ul>
+        {articles.map((article) => (
+          <li key={article.id}>{article.title}</li>
+        ))}
+      </ul>
+    </div>
+  );
 }
+


### PR DESCRIPTION
## Summary
- Retrieve news articles from Firebase Firestore and display them on the News page
- Remove unused theme reference in TournamentBracket component to satisfy lint

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e264ca5448326851f2137609b8ed7