### PR TITLE
Add reusable page layout across pages

### DIFF
--- a/platforma/src/components/PageLayout.jsx
+++ b/platforma/src/components/PageLayout.jsx
@@ -1,0 +1,18 @@
+import { Stack } from '@fluentui/react';
+import { Text } from '@fluentui/react-components';
+
+export default function PageLayout({ title, children }) {
+  return (
+    <Stack
+      tokens={{ childrenGap: 20 }}
+      styles={{ root: { width: '100%', maxWidth: 1200, margin: '0 auto', padding: 20 } }}
+    >
+      {title && (
+        <Text as="h1" size={800} block>
+          {title}
+        </Text>
+      )}
+      {children}
+    </Stack>
+  );
+}

--- a/platforma/src/pages/Article.jsx
+++ b/platforma/src/pages/Article.jsx
@@ -1,3 +1,5 @@
+import PageLayout from '../components/PageLayout';
+
 export default function Article() {
-  return <h1>Article</h1>;
+  return <PageLayout title="Article" />;
 }

--- a/platforma/src/pages/Bracket.jsx
+++ b/platforma/src/pages/Bracket.jsx
@@ -1,4 +1,5 @@
 import { Text } from '@fluentui/react-components';
+import PageLayout from '../components/PageLayout';
 import TournamentBracket from '../components/bracket/TournamentBracket';
 
 function roundName(size) {
@@ -72,10 +73,7 @@ const examples = [32, 24, 16, 12, 8, 4].map((count) => ({
 
 export default function Bracket() {
   return (
-    <div style={{ padding: 16 }}>
-      <Text as="h1" size={800} block>
-        Bracket
-      </Text>
+    <PageLayout title="Bracket">
       {examples.map((ex) => (
         <div key={ex.count} style={{ marginTop: 32 }}>
           <Text as="h2" size={500} block>
@@ -84,7 +82,6 @@ export default function Bracket() {
           <TournamentBracket rounds={ex.rounds} />
         </div>
       ))}
-    </div>
+    </PageLayout>
   );
 }
-

--- a/platforma/src/pages/Calendar.jsx
+++ b/platforma/src/pages/Calendar.jsx
@@ -1,3 +1,5 @@
+import PageLayout from '../components/PageLayout';
+
 export default function Calendar() {
-  return <h1>Calendar</h1>;
+  return <PageLayout title="Calendar" />;
 }

--- a/platforma/src/pages/Game.jsx
+++ b/platforma/src/pages/Game.jsx
@@ -1,3 +1,5 @@
+import PageLayout from '../components/PageLayout';
+
 export default function Game() {
-  return <h1>Game</h1>;
+  return <PageLayout title="Game" />;
 }

--- a/platforma/src/pages/Home.jsx
+++ b/platforma/src/pages/Home.jsx
@@ -1,10 +1,10 @@
 import ImageCarousel from '../components/ImageCarousel';
+import PageLayout from '../components/PageLayout';
 
 export default function Home() {
   return (
-    <div>
-      <h1>Home</h1>
+    <PageLayout title="Home">
       <ImageCarousel />
-    </div>
+    </PageLayout>
   );
 }

--- a/platforma/src/pages/League.jsx
+++ b/platforma/src/pages/League.jsx
@@ -1,3 +1,5 @@
+import PageLayout from '../components/PageLayout';
+
 export default function League() {
-  return <h1>League</h1>;
+  return <PageLayout title="League" />;
 }

--- a/platforma/src/pages/News.jsx
+++ b/platforma/src/pages/News.jsx
@@ -1,3 +1,5 @@
+import PageLayout from '../components/PageLayout';
+
 export default function News() {
-  return <h1>News</h1>;
+  return <PageLayout title="News" />;
 }

--- a/platforma/src/pages/Player.jsx
+++ b/platforma/src/pages/Player.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { doc, getDoc } from 'firebase/firestore';
 import { db } from '../firebase';
+import PageLayout from '../components/PageLayout';
 
 export default function Player() {
   const { playerId } = useParams();
@@ -37,16 +38,25 @@ export default function Player() {
     fetchPlayer();
   }, [playerId]);
 
-  if (loading) return <p>Loading player...</p>;
-  if (error) return <p>{error}</p>;
+  if (loading)
+    return (
+      <PageLayout title="Player">
+        <p>Loading player...</p>
+      </PageLayout>
+    );
+  if (error)
+    return (
+      <PageLayout title="Player">
+        <p>{error}</p>
+      </PageLayout>
+    );
   if (!player) return null;
 
   return (
-    <div>
-      <h1>{player.name}</h1>
+    <PageLayout title={player.name}>
       {player.team && <p>Team: {player.team}</p>}
       {player.position && <p>Position: {player.position}</p>}
       {player.number && <p>Number: {player.number}</p>}
-    </div>
+    </PageLayout>
   );
 }

--- a/platforma/src/pages/Players.jsx
+++ b/platforma/src/pages/Players.jsx
@@ -1,3 +1,5 @@
+import PageLayout from '../components/PageLayout';
+
 export default function Players() {
-  return <h1>Players</h1>;
+  return <PageLayout title="Players" />;
 }

--- a/platforma/src/pages/Schedule.jsx
+++ b/platforma/src/pages/Schedule.jsx
@@ -1,3 +1,5 @@
+import PageLayout from '../components/PageLayout';
+
 export default function Schedule() {
-  return <h1>Schedule</h1>;
+  return <PageLayout title="Schedule" />;
 }

--- a/platforma/src/pages/Season.jsx
+++ b/platforma/src/pages/Season.jsx
@@ -1,3 +1,5 @@
+import PageLayout from '../components/PageLayout';
+
 export default function Season() {
-  return <h1>Season</h1>;
+  return <PageLayout title="Season" />;
 }

--- a/platforma/src/pages/Standings.jsx
+++ b/platforma/src/pages/Standings.jsx
@@ -1,3 +1,5 @@
+import PageLayout from '../components/PageLayout';
+
 export default function Standings() {
-  return <h1>Standings</h1>;
+  return <PageLayout title="Standings" />;
 }

--- a/platforma/src/pages/Team.jsx
+++ b/platforma/src/pages/Team.jsx
@@ -1,3 +1,5 @@
+import PageLayout from '../components/PageLayout';
+
 export default function Team() {
-  return <h1>Team</h1>;
+  return <PageLayout title="Team" />;
 }

--- a/platforma/src/pages/Teams.jsx
+++ b/platforma/src/pages/Teams.jsx
@@ -1,3 +1,5 @@
+import PageLayout from '../components/PageLayout';
+
 export default function Teams() {
-  return <h1>Teams</h1>;
+  return <PageLayout title="Teams" />;
 }

--- a/platforma/src/pages/Tournament.jsx
+++ b/platforma/src/pages/Tournament.jsx
@@ -1,3 +1,5 @@
+import PageLayout from '../components/PageLayout';
+
 export default function Tournament() {
-  return <h1>Tournament</h1>;
+  return <PageLayout title="Tournament" />;
 }

--- a/platforma/src/pages/Venue.jsx
+++ b/platforma/src/pages/Venue.jsx
@@ -1,13 +1,16 @@
+import PageLayout from '../components/PageLayout';
 import VenueComponent from '../components/Venue';
 
 export default function Venue() {
   return (
-    <VenueComponent
-      name="Mitch Richmond Arena"
-      image="https://placehold.co/800x400"
-      address="Kazimierza Górskiego 10, 81-304 Gdynia, Poland"
-      description="Boisko nr 2 na kortach Arki"
-      location="Kazimierza Górskiego 10, 81-304 Gdynia, Poland"
-    />
+    <PageLayout>
+      <VenueComponent
+        name="Mitch Richmond Arena"
+        image="https://placehold.co/800x400"
+        address="Kazimierza Górskiego 10, 81-304 Gdynia, Poland"
+        description="Boisko nr 2 na kortach Arki"
+        location="Kazimierza Górskiego 10, 81-304 Gdynia, Poland"
+      />
+    </PageLayout>
   );
 }


### PR DESCRIPTION
## Summary
- add shared PageLayout component for consistent spacing and titles
- apply PageLayout across all pages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f2bd9c1ec83268d6d0612a6183fcf