### PR TITLE
Style player detail page with Fluent UI

### DIFF
--- a/platforma/src/pages/Player.jsx
+++ b/platforma/src/pages/Player.jsx
@@ -1,7 +1,29 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { doc, getDoc } from 'firebase/firestore';
+import {
+  Card,
+  Text,
+  Spinner,
+  makeStyles,
+  shorthands,
+  tokens,
+} from '@fluentui/react-components';
 import { db } from '../firebase';
+
+const useStyles = makeStyles({
+  container: {
+    maxWidth: '400px',
+    margin: '0 auto',
+    ...shorthands.padding('24px'),
+    display: 'flex',
+    flexDirection: 'column',
+    rowGap: '8px',
+  },
+  label: {
+    color: tokens.colorNeutralForeground2,
+  },
+});
 
 export default function Player() {
   const { playerId } = useParams();
@@ -37,16 +59,32 @@ export default function Player() {
     fetchPlayer();
   }, [playerId]);
 
-  if (loading) return <p>Loading player...</p>;
-  if (error) return <p>{error}</p>;
+  const styles = useStyles();
+
+  if (loading) return <Spinner label="Loading player..." />;
+  if (error) return <Text>{error}</Text>;
   if (!player) return null;
 
   return (
-    <div>
-      <h1>{player.name}</h1>
-      {player.team && <p>Team: {player.team}</p>}
-      {player.position && <p>Position: {player.position}</p>}
-      {player.number && <p>Number: {player.number}</p>}
-    </div>
+    <Card className={styles.container} appearance="filled">
+      <Text as="h1" size={800} weight="semibold" block>
+        {player.name}
+      </Text>
+      {player.team && (
+        <Text className={styles.label} block>
+          Team: {player.team}
+        </Text>
+      )}
+      {player.position && (
+        <Text className={styles.label} block>
+          Position: {player.position}
+        </Text>
+      )}
+      {player.number && (
+        <Text className={styles.label} block>
+          Number: {player.number}
+        </Text>
+      )}
+    </Card>
   );
 }


### PR DESCRIPTION
## Summary
- style player detail page with Fluent UI components and custom makeStyles layout

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f2becbcbc8326a6f0fe14d51003ca