### PR TITLE
feat: add sponsor carousel above footer

### DIFF
--- a/platforma/src/App.jsx
+++ b/platforma/src/App.jsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 import { Routes, Route, Navigate } from 'react-router-dom';
 import Navbar from './components/Navbar';
 import Footer from './components/Footer';
+import SponsorsBar from './components/SponsorsBar';
 import Home from './pages/Home';
 import Article from './pages/Article';
 import News from './pages/News';
@@ -50,6 +51,7 @@ export default function App() {
           <Route path="/bracket" element={<Bracket />} />
           <Route path="/calendar" element={<Calendar />} />
         </Routes>
+        <SponsorsBar />
         <Footer />
       </Stack>
     </FluentProvider>

--- a/platforma/src/App.jsx
+++ b/platforma/src/App.jsx
@@ -51,8 +51,10 @@ export default function App() {
           <Route path="/bracket" element={<Bracket />} />
           <Route path="/calendar" element={<Calendar />} />
         </Routes>
-        <SponsorsBar />
-        <Footer />
+        <Stack tokens={{ childrenGap: 0 }}>
+          <SponsorsBar />
+          <Footer />
+        </Stack>
       </Stack>
     </FluentProvider>
   );

--- a/platforma/src/components/SponsorsBar.css
+++ b/platforma/src/components/SponsorsBar.css
@@ -1,0 +1,15 @@
+.sponsor-fade {
+  animation: sponsorFade 1s ease-in-out;
+}
+
+@keyframes sponsorFade {
+  from {
+    opacity: 0;
+    transform: translateX(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+

--- a/platforma/src/components/SponsorsBar.jsx
+++ b/platforma/src/components/SponsorsBar.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Stack } from '@fluentui/react';
+import './SponsorsBar.css';
 
 const sponsors = [
   'DOMBI',
@@ -41,7 +42,13 @@ export default function SponsorsBar() {
         justifyContent: 'center',
       }}
     >
-      <Stack horizontal verticalAlign="center" tokens={{ childrenGap: 8 }}>
+      <Stack
+        key={index}
+        className="sponsor-fade"
+        horizontal
+        verticalAlign="center"
+        tokens={{ childrenGap: 8 }}
+      >
         {visible}
       </Stack>
     </div>

--- a/platforma/src/components/SponsorsBar.jsx
+++ b/platforma/src/components/SponsorsBar.jsx
@@ -1,0 +1,43 @@
+import { useState } from 'react';
+import { Stack, IconButton } from '@fluentui/react';
+
+const sponsors = [
+  'DOMBI',
+  'METALZBYT',
+  'TREFL SOPOT',
+  'KLIMAZBYT HURTOWNIA BRANŻOWA',
+  'USZYTE',
+  'KINGUIN ESPORTS LOUNGE',
+  'ARKA GDYNIA',
+  'HEMPATIA',
+  'POLITECHNIKA GDAŃSKA',
+  'KOCHAMY AKTYWNOŚĆ',
+  'SKLEP KOSZYKARZA',
+];
+
+export default function SponsorsBar() {
+  const [index, setIndex] = useState(0);
+  const prev = () => setIndex((index - 1 + sponsors.length) % sponsors.length);
+  const next = () => setIndex((index + 1) % sponsors.length);
+
+  const sponsor = sponsors[index];
+  const imageUrl = `https://placehold.co/160x80?text=${encodeURIComponent(sponsor)}`;
+
+  return (
+    <div
+      style={{
+        padding: 10,
+        background: 'var(--colorNeutralBackground1)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <Stack horizontal verticalAlign="center" tokens={{ childrenGap: 8 }}>
+        <IconButton iconProps={{ iconName: 'ChevronLeft' }} ariaLabel="Previous sponsor" onClick={prev} />
+        <img src={imageUrl} alt={sponsor} style={{ height: 80 }} />
+        <IconButton iconProps={{ iconName: 'ChevronRight' }} ariaLabel="Next sponsor" onClick={next} />
+      </Stack>
+    </div>
+  );
+}

--- a/platforma/src/components/SponsorsBar.jsx
+++ b/platforma/src/components/SponsorsBar.jsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
-import { Stack, IconButton } from '@fluentui/react';
+import { useEffect, useState } from 'react';
+import { Stack } from '@fluentui/react';
 
 const sponsors = [
   'DOMBI',
@@ -17,11 +17,19 @@ const sponsors = [
 
 export default function SponsorsBar() {
   const [index, setIndex] = useState(0);
-  const prev = () => setIndex((index - 1 + sponsors.length) % sponsors.length);
-  const next = () => setIndex((index + 1) % sponsors.length);
 
-  const sponsor = sponsors[index];
-  const imageUrl = `https://placehold.co/160x80?text=${encodeURIComponent(sponsor)}`;
+  useEffect(() => {
+    const id = setInterval(() => {
+      setIndex((i) => (i + 1) % sponsors.length);
+    }, 3000);
+    return () => clearInterval(id);
+  }, []);
+
+  const visible = Array.from({ length: 6 }, (_, i) => {
+    const sponsor = sponsors[(index + i) % sponsors.length];
+    const imageUrl = `https://placehold.co/160x80?text=${encodeURIComponent(sponsor)}`;
+    return <img key={sponsor} src={imageUrl} alt={sponsor} style={{ height: 80 }} />;
+  });
 
   return (
     <div
@@ -34,9 +42,7 @@ export default function SponsorsBar() {
       }}
     >
       <Stack horizontal verticalAlign="center" tokens={{ childrenGap: 8 }}>
-        <IconButton iconProps={{ iconName: 'ChevronLeft' }} ariaLabel="Previous sponsor" onClick={prev} />
-        <img src={imageUrl} alt={sponsor} style={{ height: 80 }} />
-        <IconButton iconProps={{ iconName: 'ChevronRight' }} ariaLabel="Next sponsor" onClick={next} />
+        {visible}
       </Stack>
     </div>
   );


### PR DESCRIPTION
## Summary
- add SponsorsBar component using Fluent UI to cycle through sponsor placeholders
- display SponsorsBar above footer in app

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f6dacade883268bb87c4a4334c79e