### PR TITLE
Add news cards to home page

### DIFF
--- a/platforma/src/pages/Home.jsx
+++ b/platforma/src/pages/Home.jsx
@@ -8,6 +8,7 @@ import {
   tokens,
 } from '@fluentui/react-components';
 import { Image } from '@fluentui/react';
+import { useNavigate } from 'react-router-dom';
 
 const newsItems = [
   {
@@ -24,16 +25,6 @@ const newsItems = [
     title: 'Community outreach initiative',
     image: 'https://placehold.co/300x200?text=News+3',
     story: 'Teams collaborate with local groups for youth development.',
-  },
-  {
-    title: 'Mid-season tournament announced',
-    image: 'https://placehold.co/300x200?text=News+4',
-    story: 'A new tournament will test squads in a high-stakes showdown.',
-  },
-  {
-    title: 'Championship game venue revealed',
-    image: 'https://placehold.co/300x200?text=News+5',
-    story: 'The final match will be held at a newly renovated arena.',
   },
 ];
 
@@ -63,6 +54,7 @@ const useStyles = makeStyles({
 
 export default function Home() {
   const styles = useStyles();
+  const navigate = useNavigate();
   return (
     <PageLayout title="Home">
       <ImageCarousel />
@@ -76,6 +68,13 @@ export default function Home() {
             <Text>{item.story}</Text>
           </Card>
         ))}
+        <Card
+          className={styles.card}
+          onClick={() => navigate('/news')}
+          style={{ cursor: 'pointer', justifyContent: 'center', alignItems: 'center' }}
+        >
+          <Text weight="semibold">View all news</Text>
+        </Card>
       </div>
     </PageLayout>
   );

--- a/platforma/src/pages/Home.jsx
+++ b/platforma/src/pages/Home.jsx
@@ -1,10 +1,82 @@
 import ImageCarousel from '../components/ImageCarousel';
 import PageLayout from '../components/PageLayout';
+import {
+  Card,
+  Text,
+  makeStyles,
+  shorthands,
+  tokens,
+} from '@fluentui/react-components';
+import { Image } from '@fluentui/react';
+
+const newsItems = [
+  {
+    title: 'League kicks off new season',
+    image: 'https://placehold.co/300x200?text=News+1',
+    story: 'The new season starts with intense matches and fresh rivalries.',
+  },
+  {
+    title: 'Star player joins the roster',
+    image: 'https://placehold.co/300x200?text=News+2',
+    story: 'A top athlete signs with the team, boosting championship hopes.',
+  },
+  {
+    title: 'Community outreach initiative',
+    image: 'https://placehold.co/300x200?text=News+3',
+    story: 'Teams collaborate with local groups for youth development.',
+  },
+  {
+    title: 'Mid-season tournament announced',
+    image: 'https://placehold.co/300x200?text=News+4',
+    story: 'A new tournament will test squads in a high-stakes showdown.',
+  },
+  {
+    title: 'Championship game venue revealed',
+    image: 'https://placehold.co/300x200?text=News+5',
+    story: 'The final match will be held at a newly renovated arena.',
+  },
+];
+
+const useStyles = makeStyles({
+  newsGrid: {
+    marginTop: '20px',
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fill, minmax(240px, 1fr))',
+    gap: '20px',
+  },
+  card: {
+    display: 'flex',
+    flexDirection: 'column',
+    rowGap: '8px',
+    ...shorthands.padding('16px'),
+    ...shorthands.borderRadius(tokens.borderRadiusMedium),
+    boxShadow: tokens.shadow4,
+    backgroundColor: tokens.colorNeutralBackground1,
+  },
+  image: {
+    width: '100%',
+    height: '120px',
+    objectFit: 'cover',
+    ...shorthands.borderRadius(tokens.borderRadiusSmall),
+  },
+});
 
 export default function Home() {
+  const styles = useStyles();
   return (
     <PageLayout title="Home">
       <ImageCarousel />
+      <div className={styles.newsGrid}>
+        {newsItems.map((item) => (
+          <Card key={item.title} className={styles.card}>
+            <Image src={item.image} alt={item.title} className={styles.image} />
+            <Text weight="semibold" as="h3">
+              {item.title}
+            </Text>
+            <Text>{item.story}</Text>
+          </Card>
+        ))}
+      </div>
     </PageLayout>
   );
 }


### PR DESCRIPTION
## Summary
- Display a grid of five recent news cards beneath the home page image carousel.
- Each card shows an image, title, and brief story using Fluent UI styling.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f6e98ba708326a9492f9aad183fc5