### PR TITLE
Add custom Round of 8 bracket example

### DIFF
--- a/platforma/src/components/bracket/TournamentBracket.jsx
+++ b/platforma/src/components/bracket/TournamentBracket.jsx
@@ -1,89 +1,138 @@
+import * as React from 'react';
 import {
   Card,
+  CardHeader,
   Text,
+  Caption1,
+  Badge,
+  Tooltip,
   makeStyles,
   shorthands,
   tokens,
   mergeClasses,
 } from '@fluentui/react-components';
-import { useState } from 'react';
+import { Trophy24Regular, Branch24Regular } from '@fluentui/react-icons';
 
 const useStyles = makeStyles({
-  bracket: {
-    display: 'flex',
-    columnGap: '32px',
-    alignItems: 'flex-start',
+  root: {
+    display: 'grid',
+    gridAutoFlow: 'column',
+    gridAutoColumns: 'max-content',
+    columnGap: tokens.spacingHorizontalXL,
+    width: '100%',
+    overflowX: 'auto',
+    overflowY: 'hidden',
+    ...shorthands.padding(tokens.spacingVerticalM, tokens.spacingHorizontalM),
   },
   round: {
-    display: 'flex',
-    flexDirection: 'column',
+    minWidth: '240px',
+    display: 'grid',
+    rowGap: tokens.spacingVerticalS,
   },
-  match: {
-    minWidth: '200px',
-    height: '64px',
-    position: 'relative',
+  roundHeader: {
+    position: 'sticky',
+    top: 0,
+    zIndex: 1,
     display: 'flex',
-    flexDirection: 'column',
-    justifyContent: 'center',
-    overflow: 'visible',
-  },
-  team: {
-    display: 'flex',
-    justifyContent: 'space-between',
     alignItems: 'center',
-    columnGap: '4px',
-    selectors: {
-      '&:not(:last-child)': {
-        borderBottom: `2px solid ${tokens.colorNeutralStroke3}`,
-      },
+    gap: tokens.spacingHorizontalSNudge,
+    backgroundColor: 'var(--colorNeutralBackground1)',
+    ...shorthands.padding(tokens.spacingVerticalSNudge, 0),
+  },
+  matchesStack: {
+    display: 'block',
+  },
+  matchCard: {
+    position: 'relative',
+    minWidth: '220px',
+    height: '72px',
+    display: 'grid',
+    gridTemplateRows: '1fr 1fr',
+    rowGap: 0,
+    backgroundColor: 'var(--colorNeutralBackground1)',
+    boxShadow: tokens.shadow16,
+    ...shorthands.border('1px', 'solid', 'var(--colorNeutralStroke2)'),
+    ...shorthands.borderRadius(tokens.borderRadiusLarge),
+    transitionProperty: 'transform, box-shadow',
+    transitionDuration: tokens.durationNormal,
+    ':hover': {
+      transform: 'translateY(-2px)',
+      boxShadow: tokens.shadow28,
     },
+  },
+  teamRow: {
+    display: 'grid',
+    gridTemplateColumns: '1fr auto',
+    alignItems: 'center',
+    columnGap: tokens.spacingHorizontalS,
+    ...shorthands.padding(tokens.spacingVerticalSNudge, tokens.spacingHorizontalM),
+    // subtle divider between rows
+    ':first-of-type': {
+      boxShadow: 'inset 0 -1px var(--colorNeutralStroke2)'
+    },
+  },
+  teamName: {
+    minWidth: 0,
+    overflow: 'hidden',
+    whiteSpace: 'nowrap',
+    textOverflow: 'ellipsis',
+  },
+  scorePill: {
+    justifySelf: 'end',
+    fontVariantNumeric: 'tabular-nums',
+    ...shorthands.padding('2px', tokens.spacingHorizontalSNudge),
+    ...shorthands.borderRadius(tokens.borderRadiusMedium),
+  },
+  scoreWin: {
+    backgroundColor: tokens.colorStatusSuccessBackground3,
+    color: tokens.colorNeutralForegroundOnBrand,
+  },
+  scoreLose: {
+    backgroundColor: tokens.colorStatusDangerBackground3,
+    color: tokens.colorNeutralForegroundOnBrand,
   },
   highlight: {
     backgroundColor: tokens.colorBrandBackground,
     color: tokens.colorNeutralForegroundOnBrand,
+    ':first-of-type': {
+      boxShadow: 'inset 0 -1px rgba(255,255,255,0.2)'
+    },
   },
-  score: {
-    display: 'flex',
-    alignItems: 'center',
-    columnGap: '4px',
-  },
-  scoreValue: {
-    ...shorthands.padding('2px', '4px'),
-    ...shorthands.borderRadius(tokens.borderRadiusSmall),
-  },
-  winScore: {
-    backgroundColor: tokens.colorStatusSuccessBackground3,
-    color: tokens.colorNeutralForegroundOnBrand,
-  },
-  loseScore: {
-    backgroundColor: tokens.colorStatusDangerBackground3,
-    color: tokens.colorNeutralForegroundOnBrand,
-  },
-  lineRight: {
+  connectorHorizontalRight: {
     position: 'absolute',
     top: '50%',
     right: '-16px',
     width: '16px',
     height: '2px',
     transform: 'translateY(-50%)',
+    backgroundColor: 'var(--colorNeutralStroke2)',
   },
-  lineLeft: {
+  connectorHorizontalLeft: {
     position: 'absolute',
     top: '50%',
     left: '-16px',
     width: '16px',
     height: '2px',
     transform: 'translateY(-50%)',
+    backgroundColor: 'var(--colorNeutralStroke2)',
   },
-  lineVerticalRight: {
+  connectorVerticalRight: {
     position: 'absolute',
     right: '-16px',
     width: '2px',
+    backgroundColor: 'var(--colorNeutralStroke2)',
   },
-  lineVerticalLeft: {
+  connectorVerticalLeft: {
     position: 'absolute',
     left: '-16px',
-    width: '0',
+    width: '2px',
+    backgroundColor: 'var(--colorNeutralStroke2)',
+  },
+  finalsBadge: {
+    marginInlineStart: tokens.spacingHorizontalSNudge,
+  },
+  thirdPlaceSpacer: {
+    height: tokens.spacingVerticalXL,
   },
 });
 
@@ -99,144 +148,161 @@ function Match({
   setHoveredTeamId,
 }) {
   const styles = useStyles();
-  const connectorColor = tokens.colorNeutralForeground3Hover;
+
   const winnerIndex =
     sides[0].score === undefined
       ? 1
       : sides[1].score === undefined
-        ? 0
-        : sides[0].score >= sides[1].score
-          ? 0
-          : 1;
+      ? 0
+      : sides[0].score >= sides[1].score
+      ? 0
+      : 1;
+
+  const getScoreClass = (isWinner) =>
+    mergeClasses(styles.scorePill, isWinner ? styles.scoreWin : styles.scoreLose);
+
   return (
-    <Card className={styles.match} appearance="filled" style={style}>
+    <Card appearance="filled" className={styles.matchCard} style={style} aria-label={`${sides[0]?.team ?? 'TBD'} vs ${sides[1]?.team ?? 'TBD'}`}>
       {sides.map((side, i) => {
         const isWinner = winnerIndex === i;
         const isHovered = hoveredTeamId === side.id;
+        const rowClasses = mergeClasses(styles.teamRow, isHovered && styles.highlight);
+        const scoreClasses = getScoreClass(isWinner);
         return (
-          <div
-            key={side.id ?? i}
-            className={mergeClasses(styles.team, isHovered && styles.highlight)}
-            onMouseEnter={() => setHoveredTeamId(side.id)}
-            onMouseLeave={() => setHoveredTeamId(null)}
-          >
-            <Text weight={isWinner ? 'bold' : 'regular'}>{side.team}</Text>
-            <div className={styles.score}>
-              {side.score !== undefined && (
-                <Text
-                  weight={isWinner ? 'bold' : 'regular'}
-                  className={mergeClasses(
-                    styles.scoreValue,
-                    isWinner ? styles.winScore : styles.loseScore,
-                  )}
-                >
+          <Tooltip key={side.id ?? i} content={side.team} relationship="description">
+            <div
+              className={rowClasses}
+              onMouseEnter={() => setHoveredTeamId(side.id)}
+              onMouseLeave={() => setHoveredTeamId(null)}
+              role="button"
+              tabIndex={0}
+            >
+              <Text weight={isWinner ? 'semibold' : 'regular'} className={styles.teamName}>
+                {side.team ?? 'TBD'}
+              </Text>
+              {side.score !== undefined ? (
+                <Text weight={isWinner ? 'semibold' : 'regular'} className={scoreClasses}>
                   {side.score}
                 </Text>
+              ) : (
+                <Badge appearance="outline" size="tiny">—</Badge>
               )}
             </div>
-          </div>
+          </Tooltip>
         );
       })}
-      {hasNext && (
-        <div
-          className={styles.lineRight}
-          style={{ backgroundColor: connectorColor }}
-        />
-      )}
-      {hasPrev && (
-        <div
-          className={styles.lineLeft}
-          style={{ backgroundColor: connectorColor }}
-        />
-      )}
+
+      {/* Connectors */}
+      {hasNext && <div className={styles.connectorHorizontalRight} />}
+      {hasPrev && <div className={styles.connectorHorizontalLeft} />}
       {hasNext && index % 2 === 0 && (
         <div
-          className={styles.lineVerticalRight}
-          style={{
-            top: '50%',
-            height: nextConnectorHeight,
-            backgroundColor: connectorColor,
-          }}
+          className={styles.connectorVerticalRight}
+          style={{ top: '50%', height: nextConnectorHeight }}
         />
       )}
       {hasPrev && (
         <div
-          className={styles.lineVerticalLeft}
-          style={{
-            top: `calc(50% - ${prevConnectorHeight / 2}px)`,
-            height: prevConnectorHeight,
-            backgroundColor: connectorColor,
-          }}
+          className={styles.connectorVerticalLeft}
+          style={{ top: `calc(50% - ${prevConnectorHeight / 2}px)`, height: prevConnectorHeight }}
         />
       )}
+
+      {/* Hidden header for better screen reader context */}
+      <CardHeader visuallyHidden header={<Text>{`${sides[0]?.team ?? 'TBD'} vs ${sides[1]?.team ?? 'TBD'}`}</Text>} />
     </Card>
   );
 }
 
 export default function TournamentBracket({ rounds = [] }) {
   const styles = useStyles();
-  const [hoveredTeamId, setHoveredTeamId] = useState(null);
-  const matchHeight = 64;
-  const matchSpacing = matchHeight + 24; // match height + gap
+  const [hoveredTeamId, setHoveredTeamId] = React.useState(null);
+
+  // Layout metrics
+  const matchHeight = 72;
+  const matchSpacing = matchHeight + 28; // height + gap
+
   const thirdPlaceRound = rounds.find((r) => r.name === 'Third Place');
   const displayRounds = rounds.filter((r) => r.name !== 'Third Place');
+
   return (
-    <div className={styles.bracket}>
+    <div className={styles.root}>
       {displayRounds.map((round, rIndex) => {
-        const isFinal = round.name === 'Finals';
+        const isFinal = round.name?.toLowerCase?.() === 'finals' || round.name?.toLowerCase?.() === 'final';
         return (
           <div key={rIndex} className={styles.round}>
-            <Text weight="semibold">{round.name}</Text>
-            {round.matches.map((match, mIndex) => {
-              const spacing = matchSpacing * Math.pow(2, rIndex);
-              const offset = rIndex === 0 ? 0 : spacing / 2 - matchHeight / 2;
-              const marginTop = mIndex === 0 ? offset : spacing - matchHeight;
-              const hasPrev = rIndex > 0;
-              const hasNext = rIndex < displayRounds.length - 1;
-              const prevSpacing = matchSpacing * Math.pow(2, rIndex - 1);
-              const nextSpacing = spacing;
-              return (
-                <Match
-                  key={match.id}
-                  sides={match.sides}
-                  hasPrev={hasPrev}
-                  hasNext={hasNext}
-                  index={mIndex}
-                  prevConnectorHeight={prevSpacing}
-                  nextConnectorHeight={nextSpacing}
-                  style={{ marginTop }}
-                  hoveredTeamId={hoveredTeamId}
-                  setHoveredTeamId={setHoveredTeamId}
-                />
-              );
-            })}
-            {isFinal && thirdPlaceRound && (
-              <>
-                <Text weight="semibold" style={{ marginTop: matchSpacing }}>
-                  {thirdPlaceRound.name}
-                </Text>
-                {thirdPlaceRound.matches.map((match, mIndex) => {
-                  const marginTop = mIndex === 0 ? 0 : matchSpacing - matchHeight;
-                  return (
-                    <Match
-                      key={match.id}
-                      sides={match.sides}
-                      hasPrev={false}
-                      hasNext={false}
-                      index={mIndex}
-                      prevConnectorHeight={0}
-                      nextConnectorHeight={0}
-                      style={{ marginTop }}
-                      hoveredTeamId={hoveredTeamId}
-                      setHoveredTeamId={setHoveredTeamId}
-                    />
-                  );
-                })}
-              </>
-            )}
+            <div className={styles.roundHeader}>
+              {isFinal ? <Trophy24Regular /> : <Branch24Regular />}
+              <Text weight="semibold">{round.name}</Text>
+              {isFinal && (
+                <Badge size="small" appearance="tint" color="brand" className={styles.finalsBadge}>
+                  Title Match
+                </Badge>
+              )}
+            </div>
+
+            <div className={styles.matchesStack}>
+              {round.matches.map((match, mIndex) => {
+                const spacing = matchSpacing * Math.pow(2, rIndex);
+                const offset = rIndex === 0 ? 0 : spacing / 2 - matchHeight / 2;
+                const marginTop = mIndex === 0 ? offset : spacing - matchHeight;
+                const hasPrev = rIndex > 0;
+                const hasNext = rIndex < displayRounds.length - 1;
+                const prevSpacing = matchSpacing * Math.pow(2, rIndex - 1);
+                const nextSpacing = spacing;
+                return (
+                  <Match
+                    key={match.id ?? `${rIndex}-${mIndex}`}
+                    sides={match.sides}
+                    hasPrev={hasPrev}
+                    hasNext={hasNext}
+                    index={mIndex}
+                    prevConnectorHeight={prevSpacing}
+                    nextConnectorHeight={nextSpacing}
+                    style={{ marginTop }}
+                    hoveredTeamId={hoveredTeamId}
+                    setHoveredTeamId={setHoveredTeamId}
+                  />
+                );
+              })}
+
+              {/* Third place column appears under finals */}
+              {isFinal && thirdPlaceRound && (
+                <>
+                  <div className={styles.thirdPlaceSpacer} />
+                  <div className={styles.roundHeader}>
+                    <Branch24Regular />
+                    <Text weight="semibold">{thirdPlaceRound.name}</Text>
+                    <Badge size="tiny" appearance="outline">Placement</Badge>
+                  </div>
+                  {thirdPlaceRound.matches.map((match, mIndex) => {
+                    const marginTop = mIndex === 0 ? 0 : matchSpacing - matchHeight;
+                    return (
+                      <Match
+                        key={match.id ?? `third-${mIndex}`}
+                        sides={match.sides}
+                        hasPrev={false}
+                        hasNext={false}
+                        index={mIndex}
+                        prevConnectorHeight={0}
+                        nextConnectorHeight={0}
+                        style={{ marginTop }}
+                        hoveredTeamId={hoveredTeamId}
+                        setHoveredTeamId={setHoveredTeamId}
+                      />
+                    );
+                  })}
+                </>
+              )}
+            </div>
           </div>
         );
       })}
+
+      {/* Screen-reader only label */}
+      <Caption1 visuallyHidden>
+        Tournament bracket. Use left and right arrow keys to scroll rounds.
+      </Caption1>
     </div>
   );
 }

--- a/platforma/src/components/bracket/TournamentBracket.jsx
+++ b/platforma/src/components/bracket/TournamentBracket.jsx
@@ -45,7 +45,7 @@ const useStyles = makeStyles({
   matchCard: {
     position: 'relative',
     minWidth: '280px',
-    height: '72px',
+    height: '84px',
     display: 'grid',
     gridTemplateRows: '1fr 1fr',
     rowGap: 0,
@@ -65,7 +65,7 @@ const useStyles = makeStyles({
     gridTemplateColumns: '1fr auto',
     alignItems: 'center',
     columnGap: tokens.spacingHorizontalS,
-    ...shorthands.padding(tokens.spacingVerticalSNudge, tokens.spacingHorizontalM),
+    ...shorthands.padding(tokens.spacingVerticalS, tokens.spacingHorizontalM),
     // subtle divider between rows
     ':first-of-type': {
       boxShadow: 'inset 0 -1px var(--colorNeutralStroke2)'
@@ -199,10 +199,14 @@ function Match({
       {/* Connectors */}
       {hasNext && <div className={styles.connectorHorizontalRight} />}
       {hasPrev && <div className={styles.connectorHorizontalLeft} />}
-      {hasNext && index % 2 === 0 && (
+      {hasNext && (
         <div
           className={styles.connectorVerticalRight}
-          style={{ top: '50%', height: nextConnectorHeight }}
+          style={
+            index % 2 === 0
+              ? { top: '50%', height: nextConnectorHeight / 2 }
+              : { bottom: '50%', height: nextConnectorHeight / 2 }
+          }
         />
       )}
       {hasPrev && (
@@ -223,7 +227,7 @@ export default function TournamentBracket({ rounds = [] }) {
   const [hoveredTeamId, setHoveredTeamId] = React.useState(null);
 
   // Layout metrics
-  const matchHeight = 72;
+  const matchHeight = 84;
   const matchSpacing = matchHeight + 28; // height + gap
 
   const thirdPlaceRound = rounds.find((r) => r.name === 'Third Place');

--- a/platforma/src/components/bracket/TournamentBracket.jsx
+++ b/platforma/src/components/bracket/TournamentBracket.jsx
@@ -25,7 +25,7 @@ const useStyles = makeStyles({
     ...shorthands.padding(tokens.spacingVerticalM, tokens.spacingHorizontalM),
   },
   round: {
-    minWidth: '240px',
+    minWidth: '280px',
     display: 'grid',
     rowGap: tokens.spacingVerticalS,
   },
@@ -44,7 +44,7 @@ const useStyles = makeStyles({
   },
   matchCard: {
     position: 'relative',
-    minWidth: '220px',
+    minWidth: '280px',
     height: '72px',
     display: 'grid',
     gridTemplateRows: '1fr 1fr',
@@ -105,7 +105,8 @@ const useStyles = makeStyles({
     width: '16px',
     height: '2px',
     transform: 'translateY(-50%)',
-    backgroundColor: 'var(--colorNeutralStroke2)',
+    backgroundColor: tokens.colorNeutralStroke1,
+    zIndex: 1,
   },
   connectorHorizontalLeft: {
     position: 'absolute',
@@ -114,19 +115,22 @@ const useStyles = makeStyles({
     width: '16px',
     height: '2px',
     transform: 'translateY(-50%)',
-    backgroundColor: 'var(--colorNeutralStroke2)',
+    backgroundColor: tokens.colorNeutralStroke1,
+    zIndex: 1,
   },
   connectorVerticalRight: {
     position: 'absolute',
     right: '-16px',
     width: '2px',
-    backgroundColor: 'var(--colorNeutralStroke2)',
+    backgroundColor: tokens.colorNeutralStroke1,
+    zIndex: 1,
   },
   connectorVerticalLeft: {
     position: 'absolute',
     left: '-16px',
     width: '2px',
-    backgroundColor: 'var(--colorNeutralStroke2)',
+    backgroundColor: tokens.colorNeutralStroke1,
+    zIndex: 1,
   },
   finalsBadge: {
     marginInlineStart: tokens.spacingHorizontalSNudge,

--- a/platforma/src/components/bracket/TournamentBracket.jsx
+++ b/platforma/src/components/bracket/TournamentBracket.jsx
@@ -6,6 +6,7 @@ import {
   tokens,
   mergeClasses,
 } from '@fluentui/react-components';
+import { useState } from 'react';
 
 const useStyles = makeStyles({
   bracket: {
@@ -36,6 +37,10 @@ const useStyles = makeStyles({
         borderBottom: `2px solid ${tokens.colorNeutralStroke3}`,
       },
     },
+  },
+  highlight: {
+    backgroundColor: tokens.colorBrandBackground,
+    color: tokens.colorNeutralForegroundOnBrand,
   },
   score: {
     display: 'flex',
@@ -90,6 +95,8 @@ function Match({
   prevConnectorHeight,
   nextConnectorHeight,
   style,
+  hoveredTeamId,
+  setHoveredTeamId,
 }) {
   const styles = useStyles();
   const connectorColor = tokens.colorNeutralForeground3Hover;
@@ -105,10 +112,13 @@ function Match({
     <Card className={styles.match} appearance="filled" style={style}>
       {sides.map((side, i) => {
         const isWinner = winnerIndex === i;
+        const isHovered = hoveredTeamId === side.id;
         return (
           <div
             key={side.id ?? i}
-            className={styles.team}
+            className={mergeClasses(styles.team, isHovered && styles.highlight)}
+            onMouseEnter={() => setHoveredTeamId(side.id)}
+            onMouseLeave={() => setHoveredTeamId(null)}
           >
             <Text weight={isWinner ? 'bold' : 'regular'}>{side.team}</Text>
             <div className={styles.score}>
@@ -165,6 +175,7 @@ function Match({
 
 export default function TournamentBracket({ rounds = [] }) {
   const styles = useStyles();
+  const [hoveredTeamId, setHoveredTeamId] = useState(null);
   const matchHeight = 64;
   const matchSpacing = matchHeight + 24; // match height + gap
   const thirdPlaceRound = rounds.find((r) => r.name === 'Third Place');
@@ -194,6 +205,8 @@ export default function TournamentBracket({ rounds = [] }) {
                   prevConnectorHeight={prevSpacing}
                   nextConnectorHeight={nextSpacing}
                   style={{ marginTop }}
+                  hoveredTeamId={hoveredTeamId}
+                  setHoveredTeamId={setHoveredTeamId}
                 />
               );
             })}
@@ -214,6 +227,8 @@ export default function TournamentBracket({ rounds = [] }) {
                       prevConnectorHeight={0}
                       nextConnectorHeight={0}
                       style={{ marginTop }}
+                      hoveredTeamId={hoveredTeamId}
+                      setHoveredTeamId={setHoveredTeamId}
                     />
                   );
                 })}

--- a/platforma/src/components/bracket/TournamentBracket.jsx
+++ b/platforma/src/components/bracket/TournamentBracket.jsx
@@ -25,7 +25,7 @@ const useStyles = makeStyles({
     ...shorthands.padding(tokens.spacingVerticalM, tokens.spacingHorizontalM),
   },
   round: {
-    minWidth: '280px',
+    minWidth: '360px',
     display: 'grid',
     rowGap: tokens.spacingVerticalS,
   },
@@ -44,7 +44,7 @@ const useStyles = makeStyles({
   },
   matchCard: {
     position: 'relative',
-    minWidth: '280px',
+    minWidth: '360px',
     height: '84px',
     display: 'grid',
     gridTemplateRows: '1fr 1fr',
@@ -105,7 +105,7 @@ const useStyles = makeStyles({
     width: '16px',
     height: '2px',
     transform: 'translateY(-50%)',
-    backgroundColor: tokens.colorNeutralStroke1,
+    backgroundColor: tokens.colorNeutralForeground3Hover,
     zIndex: 1,
   },
   connectorHorizontalLeft: {
@@ -115,21 +115,21 @@ const useStyles = makeStyles({
     width: '16px',
     height: '2px',
     transform: 'translateY(-50%)',
-    backgroundColor: tokens.colorNeutralStroke1,
+    backgroundColor: tokens.colorNeutralForeground3Hover,
     zIndex: 1,
   },
   connectorVerticalRight: {
     position: 'absolute',
     right: '-16px',
     width: '2px',
-    backgroundColor: tokens.colorNeutralStroke1,
+    backgroundColor: tokens.colorNeutralForeground3Hover,
     zIndex: 1,
   },
   connectorVerticalLeft: {
     position: 'absolute',
     left: '-16px',
     width: '2px',
-    backgroundColor: tokens.colorNeutralStroke1,
+    backgroundColor: tokens.colorNeutralForeground3Hover,
     zIndex: 1,
   },
   finalsBadge: {

--- a/platforma/src/components/bracket/TournamentBracket.jsx
+++ b/platforma/src/components/bracket/TournamentBracket.jsx
@@ -107,7 +107,7 @@ function Match({
         const isWinner = winnerIndex === i;
         return (
           <div
-            key={i}
+            key={side.id ?? i}
             className={styles.team}
           >
             <Text weight={isWinner ? 'bold' : 'regular'}>{side.team}</Text>

--- a/platforma/src/pages/Bracket.jsx
+++ b/platforma/src/pages/Bracket.jsx
@@ -2,86 +2,93 @@ import { Text } from '@fluentui/react-components';
 import PageLayout from '../components/PageLayout';
 import TournamentBracket from '../components/bracket/TournamentBracket';
 
-function roundName(size) {
-  if (size === 2) return 'Final';
-  if (size === 4) return 'Semifinals';
-  if (size === 8) return 'Quarterfinals';
-  return `Round of ${size}`;
-}
-
-function generateBracket(teamCount) {
-  const totalSlots = 2 ** Math.ceil(Math.log2(teamCount));
-  const seeded = Array.from({ length: totalSlots }, (_, i) =>
-    i < teamCount ? `Team ${i + 1}` : 'BYE',
-  );
-  const firstHalf = seeded.slice(0, totalSlots / 2);
-  const secondHalf = seeded.slice(totalSlots / 2);
-  const teams = [];
-  for (let i = 0; i < firstHalf.length; i++) {
-    teams.push(firstHalf[i], secondHalf[i]);
-  }
-  const rounds = [];
-  let current = teams;
-  let semifinalLosers = [];
-  let id = 1;
-  while (current.length > 1) {
-    const matches = [];
-    const next = [];
-    const losers = [];
-    for (let i = 0; i < current.length; i += 2) {
-      const t1 = current[i];
-      const t2 = current[i + 1];
-      const winner = t1 === 'BYE' ? t2 : t1;
-      const loser = t1 === 'BYE' ? t1 : t2;
-      matches.push({
-        id: id++,
+const rounds = [
+  {
+    name: 'Round of 8',
+    matches: [
+      {
+        id: 1,
         sides: [
-          { team: t1, score: t1 === 'BYE' ? undefined : 1 },
-          { team: t2, score: t2 === 'BYE' ? undefined : 0 },
+          { team: 'ITAGO GDYNIA', score: 0 },
+          { team: 'OBROŃCY TYTUŁU', score: 1 },
         ],
-      });
-      next.push(winner);
-      losers.push(loser);
-    }
-    rounds.push({ name: roundName(current.length), matches });
-    if (current.length === 4) {
-      semifinalLosers = losers;
-    }
-    current = next;
-  }
-  if (semifinalLosers.length === 2) {
-    rounds.push({
-      name: 'Third Place',
-      matches: [
-        {
-          id: id++,
-          sides: [
-            { team: semifinalLosers[0], score: 1 },
-            { team: semifinalLosers[1], score: 0 },
-          ],
-        },
-      ],
-    });
-  }
-  return rounds;
-}
-
-const examples = [32, 24, 16, 12, 8, 4].map((count) => ({
-  count,
-  rounds: generateBracket(count),
-}));
+      },
+      {
+        id: 2,
+        sides: [
+          { team: 'ZADYMIARZE', score: 0 },
+          { team: 'NIEOBLICZALNI', score: 1 },
+        ],
+      },
+      {
+        id: 3,
+        sides: [
+          { team: 'BBG', score: 0 },
+          { team: 'CZARNE KONIE', score: 1 },
+        ],
+      },
+      {
+        id: 4,
+        sides: [
+          { team: 'SKYHAWKS', score: 1 },
+          { team: 'ŻABIE KRUKI', score: 0 },
+        ],
+      },
+    ],
+  },
+  {
+    name: 'Semifinals',
+    matches: [
+      {
+        id: 5,
+        sides: [
+          { team: 'OBROŃCY TYTUŁU', score: 0 },
+          { team: 'NIEOBLICZALNI', score: 1 },
+        ],
+      },
+      {
+        id: 6,
+        sides: [
+          { team: 'CZARNE KONIE', score: 1 },
+          { team: 'SKYHAWKS', score: 0 },
+        ],
+      },
+    ],
+  },
+  {
+    name: 'Finals',
+    matches: [
+      {
+        id: 7,
+        sides: [
+          { team: 'NIEOBLICZALNI', score: 1 },
+          { team: 'CZARNE KONIE', score: 0 },
+        ],
+      },
+    ],
+  },
+  {
+    name: 'Third Place',
+    matches: [
+      {
+        id: 8,
+        sides: [
+          { team: 'OBROŃCY TYTUŁU', score: 1 },
+          { team: 'SKYHAWKS', score: 0 },
+        ],
+      },
+    ],
+  },
+];
 
 export default function Bracket() {
   return (
     <PageLayout title="Bracket">
-      {examples.map((ex) => (
-        <div key={ex.count} style={{ marginTop: 32 }}>
-          <Text as="h2" size={500} block>
-            {ex.count} teams
-          </Text>
-          <TournamentBracket rounds={ex.rounds} />
-        </div>
-      ))}
+      <Text as="h2" size={500} block>
+        Round of 8
+      </Text>
+      <TournamentBracket rounds={rounds} />
     </PageLayout>
   );
 }
+

--- a/platforma/src/pages/Bracket.jsx
+++ b/platforma/src/pages/Bracket.jsx
@@ -9,29 +9,29 @@ const rounds = [
       {
         id: 1,
         sides: [
-          { team: 'ITAGO GDYNIA', score: 0 },
-          { team: 'OBROŃCY TYTUŁU', score: 1 },
+          { id: 'itago-gdynia', team: 'ITAGO GDYNIA', score: 0 },
+          { id: 'obroncy-tytulu', team: 'OBROŃCY TYTUŁU', score: 1 },
         ],
       },
       {
         id: 2,
         sides: [
-          { team: 'ZADYMIARZE', score: 0 },
-          { team: 'NIEOBLICZALNI', score: 1 },
+          { id: 'zadymiarze', team: 'ZADYMIARZE', score: 0 },
+          { id: 'nieobliczalni', team: 'NIEOBLICZALNI', score: 1 },
         ],
       },
       {
         id: 3,
         sides: [
-          { team: 'BBG', score: 0 },
-          { team: 'CZARNE KONIE', score: 1 },
+          { id: 'bbg', team: 'BBG', score: 0 },
+          { id: 'czarne-konie', team: 'CZARNE KONIE', score: 1 },
         ],
       },
       {
         id: 4,
         sides: [
-          { team: 'SKYHAWKS', score: 1 },
-          { team: 'ŻABIE KRUKI', score: 0 },
+          { id: 'skyhawks', team: 'SKYHAWKS', score: 1 },
+          { id: 'zabie-kruki', team: 'ŻABIE KRUKI', score: 0 },
         ],
       },
     ],
@@ -42,15 +42,15 @@ const rounds = [
       {
         id: 5,
         sides: [
-          { team: 'OBROŃCY TYTUŁU', score: 0 },
-          { team: 'NIEOBLICZALNI', score: 1 },
+          { id: 'obroncy-tytulu', team: 'OBROŃCY TYTUŁU', score: 0 },
+          { id: 'nieobliczalni', team: 'NIEOBLICZALNI', score: 1 },
         ],
       },
       {
         id: 6,
         sides: [
-          { team: 'CZARNE KONIE', score: 1 },
-          { team: 'SKYHAWKS', score: 0 },
+          { id: 'czarne-konie', team: 'CZARNE KONIE', score: 1 },
+          { id: 'skyhawks', team: 'SKYHAWKS', score: 0 },
         ],
       },
     ],
@@ -61,8 +61,8 @@ const rounds = [
       {
         id: 7,
         sides: [
-          { team: 'NIEOBLICZALNI', score: 1 },
-          { team: 'CZARNE KONIE', score: 0 },
+          { id: 'nieobliczalni', team: 'NIEOBLICZALNI', score: 1 },
+          { id: 'czarne-konie', team: 'CZARNE KONIE', score: 0 },
         ],
       },
     ],
@@ -73,8 +73,8 @@ const rounds = [
       {
         id: 8,
         sides: [
-          { team: 'OBROŃCY TYTUŁU', score: 1 },
-          { team: 'SKYHAWKS', score: 0 },
+          { id: 'obroncy-tytulu', team: 'OBROŃCY TYTUŁU', score: 1 },
+          { id: 'skyhawks', team: 'SKYHAWKS', score: 0 },
         ],
       },
     ],


### PR DESCRIPTION
## Summary
- Replace generated examples with a single Round of 8 bracket
- Showcase eight named teams with NIEOBLICZALNI crowned champion

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f7241707083268b3063a6e2a21001