### PR TITLE
Add language selector and page translations

### DIFF
--- a/platforma/src/components/Footer.jsx
+++ b/platforma/src/components/Footer.jsx
@@ -1,6 +1,8 @@
 import { Text } from '@fluentui/react-components';
+import { useLanguage } from '../i18n';
 
 export default function Footer() {
+  const { t } = useLanguage();
   return (
     <div
       style={{
@@ -19,7 +21,7 @@ export default function Footer() {
         style={{ height: 40 }}
       />
       <Text style={{ color: 'var(--colorNeutralForeground1)' }} size={200}>
-        © 2023 Amateur Basketball League
+        {t('footer.copyright')}
       </Text>
     </div>
   );

--- a/platforma/src/components/Navbar.jsx
+++ b/platforma/src/components/Navbar.jsx
@@ -1,37 +1,55 @@
-import { Switch, Toolbar, ToolbarButton } from '@fluentui/react-components';
+import {
+  Switch,
+  Toolbar,
+  ToolbarButton,
+  Dropdown,
+  Option,
+} from '@fluentui/react-components';
 import { Link } from 'react-router-dom';
+import { useLanguage } from '../i18n';
 
 const navItems = [
-  { key: 'home', text: 'Home', to: '/' },
-  { key: 'article', text: 'Article', to: '/article' },
-  { key: 'news', text: 'News', to: '/news' },
-  { key: 'game', text: 'Game', to: '/game' },
-  { key: 'tournament', text: 'Tournament', to: '/tournament' },
-  { key: 'season', text: 'Season', to: '/season' },
-  { key: 'league', text: 'League', to: '/league' },
-  { key: 'player', text: 'Player', to: '/player' },
-  { key: 'players', text: 'Players', to: '/players' },
-  { key: 'team', text: 'Team', to: '/team' },
-  { key: 'teams', text: 'Teams', to: '/teams' },
-  { key: 'venue', text: 'Venue', to: '/venue' },
-  { key: 'schedule', text: 'Schedule', to: '/schedule' },
-  { key: 'standings', text: 'Standings', to: '/standings' },
-  { key: 'bracket', text: 'Bracket', to: '/bracket' },
-  { key: 'calendar', text: 'Calendar', to: '/calendar' },
+  { key: 'home', to: '/' },
+  { key: 'article', to: '/article' },
+  { key: 'news', to: '/news' },
+  { key: 'game', to: '/game' },
+  { key: 'tournament', to: '/tournament' },
+  { key: 'season', to: '/season' },
+  { key: 'league', to: '/league' },
+  { key: 'player', to: '/player' },
+  { key: 'players', to: '/players' },
+  { key: 'team', to: '/team' },
+  { key: 'teams', to: '/teams' },
+  { key: 'venue', to: '/venue' },
+  { key: 'schedule', to: '/schedule' },
+  { key: 'standings', to: '/standings' },
+  { key: 'bracket', to: '/bracket' },
+  { key: 'calendar', to: '/calendar' },
 ];
 
 export default function Navbar({ isDark, setIsDark }) {
+  const { t, language, setLanguage } = useLanguage();
   return (
     <Toolbar style={{ padding: '0 16px', background: 'var(--colorNeutralBackground1)' }}>
       {navItems.map((item) => (
         <Link key={item.key} to={item.to} style={{ textDecoration: 'none' }}>
-          <ToolbarButton appearance="subtle">{item.text}</ToolbarButton>
+          <ToolbarButton appearance="subtle">
+            {t(`navbar.${item.key}`)}
+          </ToolbarButton>
         </Link>
       ))}
-      <div style={{ marginLeft: 'auto' }}>
+      <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 8 }}>
+        <Dropdown
+          value={language}
+          onOptionSelect={(_, data) => setLanguage(data.optionValue)}
+          style={{ minWidth: 80 }}
+        >
+          <Option value="en">EN</Option>
+          <Option value="es">ES</Option>
+        </Dropdown>
         <Switch
           checked={isDark}
-          label="Dark mode"
+          label={t('navbar.darkMode')}
           onChange={(_, data) => setIsDark(!!data.checked)}
         />
       </div>

--- a/platforma/src/i18n.js
+++ b/platforma/src/i18n.js
@@ -1,0 +1,203 @@
+import { createContext, useContext, useState } from 'react';
+
+const translations = {
+  en: {
+    navbar: {
+      home: 'Home',
+      article: 'Article',
+      news: 'News',
+      game: 'Game',
+      tournament: 'Tournament',
+      season: 'Season',
+      league: 'League',
+      player: 'Player',
+      players: 'Players',
+      team: 'Team',
+      teams: 'Teams',
+      venue: 'Venue',
+      schedule: 'Schedule',
+      standings: 'Standings',
+      bracket: 'Bracket',
+      calendar: 'Calendar',
+      darkMode: 'Dark mode',
+    },
+    pages: {
+      home: 'Home',
+      article: 'Article',
+      news: 'News',
+      game: 'Game',
+      tournament: 'Tournament',
+      season: 'Season',
+      league: 'League',
+      player: 'Player',
+      players: 'Players',
+      team: 'Team',
+      teams: 'Teams',
+      venue: 'Venue',
+      schedule: 'Schedule',
+      standings: 'Standings',
+      bracket: 'Bracket',
+      calendar: 'Calendar',
+    },
+    home: {
+      newsItems: [
+        {
+          title: 'League kicks off new season',
+          image: 'https://placehold.co/300x200?text=News+1',
+          story:
+            'The new season starts with intense matches and fresh rivalries.',
+        },
+        {
+          title: 'Star player joins the roster',
+          image: 'https://placehold.co/300x200?text=News+2',
+          story:
+            'A top athlete signs with the team, boosting championship hopes.',
+        },
+        {
+          title: 'Community outreach initiative',
+          image: 'https://placehold.co/300x200?text=News+3',
+          story:
+            'Teams collaborate with local groups for youth development.',
+        },
+      ],
+      viewAllNews: 'View all news',
+    },
+    player: {
+      loading: 'Loading player...',
+      noPlayer: 'No player specified',
+      notFound: 'Player not found',
+      failed: 'Failed to load player',
+      team: 'Team',
+      position: 'Position',
+      number: 'Number',
+      birthDate: 'Birth Date',
+      birthPlace: 'Birth Place',
+      height: 'Height',
+      weight: 'Weight',
+      previousTeams: 'Previous Teams',
+    },
+    bracket: {
+      final: 'Final',
+      semifinals: 'Semifinals',
+      quarterfinals: 'Quarterfinals',
+      roundOf: 'Round of',
+      thirdPlace: 'Third Place',
+      teams: 'teams',
+      bye: 'BYE',
+    },
+    footer: {
+      copyright: '© 2023 Amateur Basketball League',
+    },
+  },
+  es: {
+    navbar: {
+      home: 'Inicio',
+      article: 'Artículo',
+      news: 'Noticias',
+      game: 'Juego',
+      tournament: 'Torneo',
+      season: 'Temporada',
+      league: 'Liga',
+      player: 'Jugador',
+      players: 'Jugadores',
+      team: 'Equipo',
+      teams: 'Equipos',
+      venue: 'Lugar',
+      schedule: 'Horario',
+      standings: 'Clasificación',
+      bracket: 'Llaves',
+      calendar: 'Calendario',
+      darkMode: 'Modo oscuro',
+    },
+    pages: {
+      home: 'Inicio',
+      article: 'Artículo',
+      news: 'Noticias',
+      game: 'Juego',
+      tournament: 'Torneo',
+      season: 'Temporada',
+      league: 'Liga',
+      player: 'Jugador',
+      players: 'Jugadores',
+      team: 'Equipo',
+      teams: 'Equipos',
+      venue: 'Lugar',
+      schedule: 'Horario',
+      standings: 'Clasificación',
+      bracket: 'Llaves',
+      calendar: 'Calendario',
+    },
+    home: {
+      newsItems: [
+        {
+          title: 'La liga inicia nueva temporada',
+          image: 'https://placehold.co/300x200?text=Noticia+1',
+          story:
+            'La nueva temporada comienza con partidos intensos y nuevas rivalidades.',
+        },
+        {
+          title: 'Jugador estrella se une al equipo',
+          image: 'https://placehold.co/300x200?text=Noticia+2',
+          story:
+            'Un atleta de primer nivel firma con el equipo, aumentando las esperanzas de campeonato.',
+        },
+        {
+          title: 'Iniciativa de alcance comunitario',
+          image: 'https://placehold.co/300x200?text=Noticia+3',
+          story:
+            'Los equipos colaboran con grupos locales para el desarrollo juvenil.',
+        },
+      ],
+      viewAllNews: 'Ver todas las noticias',
+    },
+    player: {
+      loading: 'Cargando jugador...',
+      noPlayer: 'Ningún jugador especificado',
+      notFound: 'Jugador no encontrado',
+      failed: 'No se pudo cargar el jugador',
+      team: 'Equipo',
+      position: 'Posición',
+      number: 'Número',
+      birthDate: 'Fecha de nacimiento',
+      birthPlace: 'Lugar de nacimiento',
+      height: 'Altura',
+      weight: 'Peso',
+      previousTeams: 'Equipos anteriores',
+    },
+    bracket: {
+      final: 'Final',
+      semifinals: 'Semifinales',
+      quarterfinals: 'Cuartos de final',
+      roundOf: 'Ronda de',
+      thirdPlace: 'Tercer lugar',
+      teams: 'equipos',
+      bye: 'Descansa',
+    },
+    footer: {
+      copyright: '© 2023 Liga Amateur de Baloncesto',
+    },
+  },
+};
+
+const LanguageContext = createContext({
+  language: 'en',
+  setLanguage: () => {},
+  t: (key) => key,
+});
+
+export function LanguageProvider({ children }) {
+  const [language, setLanguage] = useState('en');
+  const t = (key) =>
+    key.split('.').reduce((obj, part) => (obj ? obj[part] : undefined), translations[language]) ??
+    key;
+  return (
+    <LanguageContext.Provider value={{ language, setLanguage, t }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+}
+
+export function useLanguage() {
+  return useContext(LanguageContext);
+}
+

--- a/platforma/src/main.jsx
+++ b/platforma/src/main.jsx
@@ -1,13 +1,16 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import { BrowserRouter } from 'react-router-dom'
-import './index.css'
-import App from './App.jsx'
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import './index.css';
+import App from './App.jsx';
+import { LanguageProvider } from './i18n';
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <LanguageProvider>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </LanguageProvider>
   </StrictMode>,
-)
+);

--- a/platforma/src/pages/Article.jsx
+++ b/platforma/src/pages/Article.jsx
@@ -1,5 +1,7 @@
 import PageLayout from '../components/PageLayout';
+import { useLanguage } from '../i18n';
 
 export default function Article() {
-  return <PageLayout title="Article" />;
+  const { t } = useLanguage();
+  return <PageLayout title={t('pages.article')} />;
 }

--- a/platforma/src/pages/Bracket.jsx
+++ b/platforma/src/pages/Bracket.jsx
@@ -1,83 +1,86 @@
 import { Text } from '@fluentui/react-components';
 import PageLayout from '../components/PageLayout';
 import TournamentBracket from '../components/bracket/TournamentBracket';
-
-function roundName(size) {
-  if (size === 2) return 'Final';
-  if (size === 4) return 'Semifinals';
-  if (size === 8) return 'Quarterfinals';
-  return `Round of ${size}`;
-}
-
-function generateBracket(teamCount) {
-  const totalSlots = 2 ** Math.ceil(Math.log2(teamCount));
-  const seeded = Array.from({ length: totalSlots }, (_, i) =>
-    i < teamCount ? `Team ${i + 1}` : 'BYE',
-  );
-  const firstHalf = seeded.slice(0, totalSlots / 2);
-  const secondHalf = seeded.slice(totalSlots / 2);
-  const teams = [];
-  for (let i = 0; i < firstHalf.length; i++) {
-    teams.push(firstHalf[i], secondHalf[i]);
-  }
-  const rounds = [];
-  let current = teams;
-  let semifinalLosers = [];
-  let id = 1;
-  while (current.length > 1) {
-    const matches = [];
-    const next = [];
-    const losers = [];
-    for (let i = 0; i < current.length; i += 2) {
-      const t1 = current[i];
-      const t2 = current[i + 1];
-      const winner = t1 === 'BYE' ? t2 : t1;
-      const loser = t1 === 'BYE' ? t1 : t2;
-      matches.push({
-        id: id++,
-        sides: [
-          { team: t1, score: t1 === 'BYE' ? undefined : 1 },
-          { team: t2, score: t2 === 'BYE' ? undefined : 0 },
-        ],
-      });
-      next.push(winner);
-      losers.push(loser);
-    }
-    rounds.push({ name: roundName(current.length), matches });
-    if (current.length === 4) {
-      semifinalLosers = losers;
-    }
-    current = next;
-  }
-  if (semifinalLosers.length === 2) {
-    rounds.push({
-      name: 'Third Place',
-      matches: [
-        {
-          id: id++,
-          sides: [
-            { team: semifinalLosers[0], score: 1 },
-            { team: semifinalLosers[1], score: 0 },
-          ],
-        },
-      ],
-    });
-  }
-  return rounds;
-}
-
-const examples = [32, 24, 16, 12, 8, 4].map((count) => ({
-  count,
-  rounds: generateBracket(count),
-}));
+import { useLanguage } from '../i18n';
 
 export default function Bracket() {
+  const { t } = useLanguage();
+
+  function roundName(size) {
+    if (size === 2) return t('bracket.final');
+    if (size === 4) return t('bracket.semifinals');
+    if (size === 8) return t('bracket.quarterfinals');
+    return `${t('bracket.roundOf')} ${size}`;
+  }
+
+  function generateBracket(teamCount) {
+    const totalSlots = 2 ** Math.ceil(Math.log2(teamCount));
+    const seeded = Array.from({ length: totalSlots }, (_, i) =>
+      i < teamCount ? `${t('pages.team')} ${i + 1}` : t('bracket.bye'),
+    );
+    const firstHalf = seeded.slice(0, totalSlots / 2);
+    const secondHalf = seeded.slice(totalSlots / 2);
+    const teams = [];
+    for (let i = 0; i < firstHalf.length; i++) {
+      teams.push(firstHalf[i], secondHalf[i]);
+    }
+    const rounds = [];
+    let current = teams;
+    let semifinalLosers = [];
+    let id = 1;
+    while (current.length > 1) {
+      const matches = [];
+      const next = [];
+      const losers = [];
+      for (let i = 0; i < current.length; i += 2) {
+        const t1 = current[i];
+        const t2 = current[i + 1];
+        const winner = t1 === t('bracket.bye') ? t2 : t1;
+        const loser = t1 === t('bracket.bye') ? t1 : t2;
+        matches.push({
+          id: id++,
+          sides: [
+            { team: t1, score: t1 === t('bracket.bye') ? undefined : 1 },
+            { team: t2, score: t2 === t('bracket.bye') ? undefined : 0 },
+          ],
+        });
+        next.push(winner);
+        losers.push(loser);
+      }
+      rounds.push({ name: roundName(current.length), matches });
+      if (current.length === 4) {
+        semifinalLosers = losers;
+      }
+      current = next;
+    }
+    if (semifinalLosers.length === 2) {
+      rounds.push({
+        name: t('bracket.thirdPlace'),
+        matches: [
+          {
+            id: id++,
+            sides: [
+              { team: semifinalLosers[0], score: 1 },
+              { team: semifinalLosers[1], score: 0 },
+            ],
+          },
+        ],
+      });
+    }
+    return rounds;
+  }
+
+  const examples = [32, 24, 16, 12, 8, 4].map((count) => ({
+    count,
+    rounds: generateBracket(count),
+  }));
+
   return (
-    <PageLayout title="Bracket">
+    <PageLayout title={t('pages.bracket')}>
       {examples.map((ex) => (
         <div key={ex.count} style={{ marginTop: 32 }}>
           <Text as="h2" size={500} block>
-            {ex.count} teams
+            {ex.count} {t('bracket.teams')}
           </Text>
           <TournamentBracket rounds={ex.rounds} />
         </div>

--- a/platforma/src/pages/Calendar.jsx
+++ b/platforma/src/pages/Calendar.jsx
@@ -1,5 +1,7 @@
 import PageLayout from '../components/PageLayout';
+import { useLanguage } from '../i18n';
 
 export default function Calendar() {
-  return <PageLayout title="Calendar" />;
+  const { t } = useLanguage();
+  return <PageLayout title={t('pages.calendar')} />;
 }

--- a/platforma/src/pages/Game.jsx
+++ b/platforma/src/pages/Game.jsx
@@ -1,5 +1,7 @@
 import PageLayout from '../components/PageLayout';
+import { useLanguage } from '../i18n';
 
 export default function Game() {
-  return <PageLayout title="Game" />;
+  const { t } = useLanguage();
+  return <PageLayout title={t('pages.game')} />;
 }

--- a/platforma/src/pages/Home.jsx
+++ b/platforma/src/pages/Home.jsx
@@ -9,24 +9,7 @@ import {
 } from '@fluentui/react-components';
 import { Image } from '@fluentui/react';
 import { useNavigate } from 'react-router-dom';
-
-const newsItems = [
-  {
-    title: 'League kicks off new season',
-    image: 'https://placehold.co/300x200?text=News+1',
-    story: 'The new season starts with intense matches and fresh rivalries.',
-  },
-  {
-    title: 'Star player joins the roster',
-    image: 'https://placehold.co/300x200?text=News+2',
-    story: 'A top athlete signs with the team, boosting championship hopes.',
-  },
-  {
-    title: 'Community outreach initiative',
-    image: 'https://placehold.co/300x200?text=News+3',
-    story: 'Teams collaborate with local groups for youth development.',
-  },
-];
+import { useLanguage } from '../i18n';
 
 const useStyles = makeStyles({
   newsGrid: {
@@ -55,8 +38,10 @@ const useStyles = makeStyles({
 export default function Home() {
   const styles = useStyles();
   const navigate = useNavigate();
+  const { t } = useLanguage();
+  const newsItems = t('home.newsItems');
   return (
-    <PageLayout title="Home">
+    <PageLayout title={t('pages.home')}>
       <ImageCarousel />
       <div className={styles.newsGrid}>
         {newsItems.map((item) => (
@@ -73,7 +58,7 @@ export default function Home() {
           onClick={() => navigate('/news')}
           style={{ cursor: 'pointer', justifyContent: 'center', alignItems: 'center' }}
         >
-          <Text weight="semibold">View all news</Text>
+          <Text weight="semibold">{t('home.viewAllNews')}</Text>
         </Card>
       </div>
     </PageLayout>

--- a/platforma/src/pages/League.jsx
+++ b/platforma/src/pages/League.jsx
@@ -1,5 +1,7 @@
 import PageLayout from '../components/PageLayout';
+import { useLanguage } from '../i18n';
 
 export default function League() {
-  return <PageLayout title="League" />;
+  const { t } = useLanguage();
+  return <PageLayout title={t('pages.league')} />;
 }

--- a/platforma/src/pages/News.jsx
+++ b/platforma/src/pages/News.jsx
@@ -1,5 +1,7 @@
 import PageLayout from '../components/PageLayout';
+import { useLanguage } from '../i18n';
 
 export default function News() {
-  return <PageLayout title="News" />;
+  const { t } = useLanguage();
+  return <PageLayout title={t('pages.news')} />;
 }

--- a/platforma/src/pages/Player.jsx
+++ b/platforma/src/pages/Player.jsx
@@ -3,16 +3,18 @@ import { useParams } from 'react-router-dom';
 import { doc, getDoc } from 'firebase/firestore';
 import { db } from '../firebase';
 import PageLayout from '../components/PageLayout';
+import { useLanguage } from '../i18n';
 
 export default function Player() {
+  const { t } = useLanguage();
   const { playerId } = useParams();
   const [player, setPlayer] = useState(null);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
+  const [errorKey, setErrorKey] = useState(null);
 
   useEffect(() => {
     if (!playerId) {
-      setError('No player specified');
+      setErrorKey('noPlayer');
       setLoading(false);
       return;
     }
@@ -22,14 +24,14 @@ export default function Player() {
         const snapshot = await getDoc(doc(db, 'players', playerId));
         if (snapshot.exists()) {
           setPlayer({ id: snapshot.id, ...snapshot.data() });
-          setError(null);
+          setErrorKey(null);
         } else {
-          setError('Player not found');
+          setErrorKey('notFound');
           setPlayer(null);
         }
       } catch (err) {
         console.error(err);
-        setError('Failed to load player');
+        setErrorKey('failed');
       } finally {
         setLoading(false);
       }
@@ -40,30 +42,30 @@ export default function Player() {
 
   if (loading)
     return (
-      <PageLayout title="Player">
-        <p>Loading player...</p>
+      <PageLayout title={t('pages.player')}>
+        <p>{t('player.loading')}</p>
       </PageLayout>
     );
-  if (error)
+  if (errorKey)
     return (
-      <PageLayout title="Player">
-        <p>{error}</p>
+      <PageLayout title={t('pages.player')}>
+        <p>{t(`player.${errorKey}`)}</p>
       </PageLayout>
     );
   if (!player) return null;
 
   return (
     <PageLayout title={player.name}>
-      {player.team.name && <p>Team: {player.team}</p>}
-      {player.position && <p>Position: {player.position}</p>}
-      {player.number && <p>Number: {player.number}</p>}
-      {player.birthDate && <p>Birth Date: {player.birthDate}</p>}
-      {player.birthPlace && <p>Birth Place: {player.birthPlace}</p>}
-      {player.height && <p>Height: {player.height}</p>}
-      {player.weight && <p>Weight: {player.weight}</p>}
+      {player.team?.name && <p>{t('player.team')}: {player.team.name}</p>}
+      {player.position && <p>{t('player.position')}: {player.position}</p>}
+      {player.number && <p>{t('player.number')}: {player.number}</p>}
+      {player.birthDate && <p>{t('player.birthDate')}: {player.birthDate}</p>}
+      {player.birthPlace && <p>{t('player.birthPlace')}: {player.birthPlace}</p>}
+      {player.height && <p>{t('player.height')}: {player.height}</p>}
+      {player.weight && <p>{t('player.weight')}: {player.weight}</p>}
       {player.previousTeams?.length > 0 && (
         <div>
-          <p>Previous Teams:</p>
+          <p>{t('player.previousTeams')}:</p>
           <ul>
             {player.previousTeams.map((team) => (
               <li key={team}>{team}</li>

--- a/platforma/src/pages/Players.jsx
+++ b/platforma/src/pages/Players.jsx
@@ -1,5 +1,7 @@
 import PageLayout from '../components/PageLayout';
+import { useLanguage } from '../i18n';
 
 export default function Players() {
-  return <PageLayout title="Players" />;
+  const { t } = useLanguage();
+  return <PageLayout title={t('pages.players')} />;
 }

--- a/platforma/src/pages/Schedule.jsx
+++ b/platforma/src/pages/Schedule.jsx
@@ -1,5 +1,7 @@
 import PageLayout from '../components/PageLayout';
+import { useLanguage } from '../i18n';
 
 export default function Schedule() {
-  return <PageLayout title="Schedule" />;
+  const { t } = useLanguage();
+  return <PageLayout title={t('pages.schedule')} />;
 }

--- a/platforma/src/pages/Season.jsx
+++ b/platforma/src/pages/Season.jsx
@@ -1,5 +1,7 @@
 import PageLayout from '../components/PageLayout';
+import { useLanguage } from '../i18n';
 
 export default function Season() {
-  return <PageLayout title="Season" />;
+  const { t } = useLanguage();
+  return <PageLayout title={t('pages.season')} />;
 }

--- a/platforma/src/pages/Standings.jsx
+++ b/platforma/src/pages/Standings.jsx
@@ -1,5 +1,7 @@
 import PageLayout from '../components/PageLayout';
+import { useLanguage } from '../i18n';
 
 export default function Standings() {
-  return <PageLayout title="Standings" />;
+  const { t } = useLanguage();
+  return <PageLayout title={t('pages.standings')} />;
 }

--- a/platforma/src/pages/Team.jsx
+++ b/platforma/src/pages/Team.jsx
@@ -1,5 +1,7 @@
 import PageLayout from '../components/PageLayout';
+import { useLanguage } from '../i18n';
 
 export default function Team() {
-  return <PageLayout title="Team" />;
+  const { t } = useLanguage();
+  return <PageLayout title={t('pages.team')} />;
 }

--- a/platforma/src/pages/Teams.jsx
+++ b/platforma/src/pages/Teams.jsx
@@ -1,5 +1,7 @@
 import PageLayout from '../components/PageLayout';
+import { useLanguage } from '../i18n';
 
 export default function Teams() {
-  return <PageLayout title="Teams" />;
+  const { t } = useLanguage();
+  return <PageLayout title={t('pages.teams')} />;
 }

--- a/platforma/src/pages/Tournament.jsx
+++ b/platforma/src/pages/Tournament.jsx
@@ -1,5 +1,7 @@
 import PageLayout from '../components/PageLayout';
+import { useLanguage } from '../i18n';
 
 export default function Tournament() {
-  return <PageLayout title="Tournament" />;
+  const { t } = useLanguage();
+  return <PageLayout title={t('pages.tournament')} />;
 }

--- a/platforma/src/pages/Venue.jsx
+++ b/platforma/src/pages/Venue.jsx
@@ -1,9 +1,11 @@
 import PageLayout from '../components/PageLayout';
 import VenueComponent from '../components/Venue';
+import { useLanguage } from '../i18n';
 
 export default function Venue() {
+  const { t } = useLanguage();
   return (
-    <PageLayout>
+    <PageLayout title={t('pages.venue')}>
       <VenueComponent
         name="Mitch Richmond Arena"
         image="https://placehold.co/800x400"


### PR DESCRIPTION
## Summary
- add context-based i18n with English and Spanish strings
- add navbar language dropdown and translate items
- translate all pages and footer via new `useLanguage`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f768d7cb883269bdaf89f13e06b4b