### PR TITLE
Add structured layout for news page

### DIFF
--- a/platforma/src/pages/News.jsx
+++ b/platforma/src/pages/News.jsx
@@ -8,11 +8,11 @@ import {
   Divider,
   Badge,
   Link,
-  Image,
   makeStyles,
   shorthands,
   tokens,
 } from '@fluentui/react-components';
+import { Image } from '@fluentui/react';
 import { News20Regular, ArrowRight16Regular, MegaphoneLoud24Regular } from '@fluentui/react-icons';
 import PageLayout from '../components/PageLayout';
 


### PR DESCRIPTION
## Summary
- build News page showing latest article, three medium stories, five small cards, and list of older articles

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f772b7e088326b3d51486e34d6fbf