### PR TITLE
feat: add venues listing with filters

### DIFF
--- a/platforma/src/App.jsx
+++ b/platforma/src/App.jsx
@@ -18,6 +18,7 @@ import Players from './pages/Players';
 import Team from './pages/Team';
 import Teams from './pages/Teams';
 import Venue from './pages/Venue';
+import Venues from './pages/Venues';
 import Schedule from './pages/Schedule';
 import Standings from './pages/Standings';
 import Bracket from './pages/Bracket';
@@ -46,6 +47,7 @@ export default function App() {
           <Route path="/team" element={<Team />} />
           <Route path="/teams" element={<Teams />} />
           <Route path="/venue" element={<Venue />} />
+          <Route path="/venues" element={<Venues />} />
           <Route path="/schedule" element={<Schedule />} />
           <Route path="/standings" element={<Standings />} />
           <Route path="/bracket" element={<Bracket />} />

--- a/platforma/src/components/Navbar.jsx
+++ b/platforma/src/components/Navbar.jsx
@@ -13,7 +13,7 @@ const navItems = [
   { key: 'players', text: 'Players', to: '/players' },
   { key: 'team', text: 'Team', to: '/team' },
   { key: 'teams', text: 'Teams', to: '/teams' },
-  { key: 'venue', text: 'Venue', to: '/venue' },
+  { key: 'venues', text: 'Venues', to: '/venues' },
   { key: 'schedule', text: 'Schedule', to: '/schedule' },
   { key: 'standings', text: 'Standings', to: '/standings' },
   { key: 'bracket', text: 'Bracket', to: '/bracket' },

--- a/platforma/src/pages/Venues.jsx
+++ b/platforma/src/pages/Venues.jsx
@@ -1,0 +1,121 @@
+import { useEffect, useMemo, useState } from 'react';
+import { collection, getDocs } from 'firebase/firestore';
+import { Stack } from '@fluentui/react';
+import { Input, Dropdown, Option, Label } from '@fluentui/react-components';
+import PageLayout from '../components/PageLayout';
+import Venue from '../components/Venue';
+import { db } from '../firebase';
+
+export default function Venues() {
+  const [venues, setVenues] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [search, setSearch] = useState('');
+  const [sortOrder, setSortOrder] = useState('asc');
+  const [cityFilter, setCityFilter] = useState('');
+
+  useEffect(() => {
+    async function fetchVenues() {
+      try {
+        const snapshot = await getDocs(collection(db, 'venues'));
+        const data = snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
+        setVenues(data);
+      } catch (err) {
+        console.error(err);
+        setError('Failed to load venues');
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    fetchVenues();
+  }, []);
+
+  const cities = useMemo(() => {
+    const allCities = venues.map((v) => v.city).filter(Boolean);
+    return Array.from(new Set(allCities));
+  }, [venues]);
+
+  const filteredVenues = useMemo(() => {
+    let list = venues;
+
+    if (search) {
+      const lower = search.toLowerCase();
+      list = list.filter((v) => v.name?.toLowerCase().includes(lower));
+    }
+
+    if (cityFilter) {
+      list = list.filter((v) => v.city === cityFilter);
+    }
+
+    list = [...list].sort((a, b) => {
+      const aName = a.name?.toLowerCase() ?? '';
+      const bName = b.name?.toLowerCase() ?? '';
+      return sortOrder === 'desc'
+        ? bName.localeCompare(aName)
+        : aName.localeCompare(bName);
+    });
+
+    return list;
+  }, [venues, search, sortOrder, cityFilter]);
+
+  if (loading) {
+    return (
+      <PageLayout title="Venues">
+        <p>Loading venues...</p>
+      </PageLayout>
+    );
+  }
+
+  if (error) {
+    return (
+      <PageLayout title="Venues">
+        <p>{error}</p>
+      </PageLayout>
+    );
+  }
+
+  return (
+    <PageLayout title="Venues">
+      <Stack tokens={{ childrenGap: 16 }}>
+        <Input
+          placeholder="Search by name"
+          value={search}
+          onChange={(_, data) => setSearch(data.value)}
+        />
+        <Stack horizontal tokens={{ childrenGap: 16 }}>
+          <Label htmlFor="sort">Sort</Label>
+          <Dropdown
+            id="sort"
+            value={sortOrder}
+            onOptionSelect={(_, data) => setSortOrder(data.optionValue)}
+          >
+            <Option value="asc">A-Z</Option>
+            <Option value="desc">Z-A</Option>
+          </Dropdown>
+          <Label htmlFor="city">City</Label>
+          <Dropdown
+            id="city"
+            placeholder="All cities"
+            value={cityFilter}
+            onOptionSelect={(_, data) => setCityFilter(data.optionValue)}
+          >
+            <Option value="">All cities</Option>
+            {cities.map((city) => (
+              <Option key={city} value={city}>
+                {city}
+              </Option>
+            ))}
+          </Dropdown>
+        </Stack>
+        <Stack tokens={{ childrenGap: 20 }}>
+          {filteredVenues.map((venue) => (
+            <Venue key={venue.id} {...venue} />
+          ))}
+          {filteredVenues.length === 0 && <p>No venues found.</p>}
+        </Stack>
+      </Stack>
+    </PageLayout>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add Venues page that loads venues from Firestore
- enable search, sort, and city filter for venue list
- wire up navigation and routing for venues page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f774685d88326ad7dcb5e30071662