### PR TITLE
Add sponsors page with card layout

### DIFF
--- a/platforma/src/App.jsx
+++ b/platforma/src/App.jsx
@@ -22,6 +22,7 @@ import Schedule from './pages/Schedule';
 import Standings from './pages/Standings';
 import Bracket from './pages/Bracket';
 import Calendar from './pages/Calendar';
+import Sponsors from './pages/Sponsors';
 
 initializeIcons();
 
@@ -50,6 +51,7 @@ export default function App() {
           <Route path="/standings" element={<Standings />} />
           <Route path="/bracket" element={<Bracket />} />
           <Route path="/calendar" element={<Calendar />} />
+          <Route path="/sponsors" element={<Sponsors />} />
         </Routes>
         <Stack tokens={{ childrenGap: 0 }}>
           <SponsorsBar />

--- a/platforma/src/components/Navbar.jsx
+++ b/platforma/src/components/Navbar.jsx
@@ -18,6 +18,7 @@ const navItems = [
   { key: 'standings', text: 'Standings', to: '/standings' },
   { key: 'bracket', text: 'Bracket', to: '/bracket' },
   { key: 'calendar', text: 'Calendar', to: '/calendar' },
+  { key: 'sponsors', text: 'Sponsors', to: '/sponsors' },
 ];
 
 export default function Navbar({ isDark, setIsDark }) {

--- a/platforma/src/components/SponsorsBar.jsx
+++ b/platforma/src/components/SponsorsBar.jsx
@@ -1,20 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Stack } from '@fluentui/react';
 import './SponsorsBar.css';
-
-const sponsors = [
-  'DOMBI',
-  'METALZBYT',
-  'TREFL SOPOT',
-  'KLIMAZBYT HURTOWNIA BRANŻOWA',
-  'USZYTE',
-  'KINGUIN ESPORTS LOUNGE',
-  'ARKA GDYNIA',
-  'HEMPATIA',
-  'POLITECHNIKA GDAŃSKA',
-  'KOCHAMY AKTYWNOŚĆ',
-  'SKLEP KOSZYKARZA',
-];
+import sponsors from '../data/sponsors';
 
 export default function SponsorsBar() {
   const [index, setIndex] = useState(0);

--- a/platforma/src/data/sponsors.js
+++ b/platforma/src/data/sponsors.js
@@ -1,0 +1,15 @@
+const sponsors = [
+  'DOMBI',
+  'METALZBYT',
+  'TREFL SOPOT',
+  'KLIMAZBYT HURTOWNIA BRANŻOWA',
+  'USZYTE',
+  'KINGUIN ESPORTS LOUNGE',
+  'ARKA GDYNIA',
+  'HEMPATIA',
+  'POLITECHNIKA GDAŃSKA',
+  'KOCHAMY AKTYWNOŚĆ',
+  'SKLEP KOSZYKARZA',
+];
+
+export default sponsors;

--- a/platforma/src/pages/Sponsors.jsx
+++ b/platforma/src/pages/Sponsors.jsx
@@ -1,0 +1,59 @@
+import PageLayout from '../components/PageLayout';
+import {
+  Card,
+  Text,
+  makeStyles,
+  shorthands,
+  tokens,
+} from '@fluentui/react-components';
+import { Image } from '@fluentui/react';
+import sponsors from '../data/sponsors';
+
+const useStyles = makeStyles({
+  grid: {
+    marginTop: '20px',
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))',
+    gap: '20px',
+  },
+  card: {
+    display: 'flex',
+    flexDirection: 'column',
+    rowGap: '8px',
+    alignItems: 'center',
+    ...shorthands.padding('16px'),
+    ...shorthands.borderRadius(tokens.borderRadiusMedium),
+    boxShadow: tokens.shadow4,
+    backgroundColor: tokens.colorNeutralBackground1,
+  },
+  image: {
+    width: '100%',
+    height: '80px',
+    objectFit: 'contain',
+    ...shorthands.borderRadius(tokens.borderRadiusSmall),
+    backgroundColor: 'white',
+  },
+});
+
+export default function Sponsors() {
+  const styles = useStyles();
+  return (
+    <PageLayout title="Sponsors">
+      <div className={styles.grid}>
+        {sponsors.map((name) => (
+          <Card key={name} className={styles.card}>
+            <Image
+              src={`https://placehold.co/300x80?text=${encodeURIComponent(name)}`}
+              alt={name}
+              className={styles.image}
+            />
+            <Text weight="semibold" align="center">
+              {name}
+            </Text>
+          </Card>
+        ))}
+      </div>
+    </PageLayout>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add Sponsors page that displays all sponsors in a responsive card grid
- centralize sponsor list in a shared data file and use it in the rotating SponsorsBar
- update app routing and navigation to include the new Sponsors page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f774f78588326a5ef554fecfaf617