### PR TITLE
Add contact page with basic form

### DIFF
--- a/platforma/src/App.jsx
+++ b/platforma/src/App.jsx
@@ -22,6 +22,7 @@ import Schedule from './pages/Schedule';
 import Standings from './pages/Standings';
 import Bracket from './pages/Bracket';
 import Calendar from './pages/Calendar';
+import Contact from './pages/Contact';
 
 initializeIcons();
 
@@ -50,6 +51,7 @@ export default function App() {
           <Route path="/standings" element={<Standings />} />
           <Route path="/bracket" element={<Bracket />} />
           <Route path="/calendar" element={<Calendar />} />
+          <Route path="/contact" element={<Contact />} />
         </Routes>
         <Stack tokens={{ childrenGap: 0 }}>
           <SponsorsBar />

--- a/platforma/src/components/Navbar.jsx
+++ b/platforma/src/components/Navbar.jsx
@@ -18,6 +18,7 @@ const navItems = [
   { key: 'standings', text: 'Standings', to: '/standings' },
   { key: 'bracket', text: 'Bracket', to: '/bracket' },
   { key: 'calendar', text: 'Calendar', to: '/calendar' },
+  { key: 'contact', text: 'Contact', to: '/contact' },
 ];
 
 export default function Navbar({ isDark, setIsDark }) {

--- a/platforma/src/pages/Contact.jsx
+++ b/platforma/src/pages/Contact.jsx
@@ -1,0 +1,41 @@
+import { useState } from 'react';
+import { Stack } from '@fluentui/react';
+import { Field, Input, Textarea, Button } from '@fluentui/react-components';
+import PageLayout from '../components/PageLayout';
+
+export default function Contact() {
+  const [formData, setFormData] = useState({ name: '', email: '', message: '' });
+
+  const handleChange = (field) => (e) => {
+    setFormData({ ...formData, [field]: e.target.value });
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    console.log('Contact form submitted', formData);
+    alert('Message sent!');
+    setFormData({ name: '', email: '', message: '' });
+  };
+
+  return (
+    <PageLayout title="Contact">
+      <form onSubmit={handleSubmit}>
+        <Stack tokens={{ childrenGap: 20 }}>
+          <Field label="Name" required>
+            <Input value={formData.name} onChange={handleChange('name')} required />
+          </Field>
+          <Field label="Email" required>
+            <Input type="email" value={formData.email} onChange={handleChange('email')} required />
+          </Field>
+          <Field label="Message" required>
+            <Textarea value={formData.message} onChange={handleChange('message')} required />
+          </Field>
+          <Button type="submit" appearance="primary">
+            Send
+          </Button>
+        </Stack>
+      </form>
+    </PageLayout>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add Contact page with a form for name, email, and message
- wire contact page into router and navigation bar

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f77559760832696e363d1b15a74b8