### PR TITLE
feat: add page surface styling with Fluent UI

### DIFF
--- a/platforma/src/App.jsx
+++ b/platforma/src/App.jsx
@@ -1,5 +1,5 @@
 import { initializeIcons, Stack } from '@fluentui/react';
-import { FluentProvider } from '@fluentui/react-components';
+import { FluentProvider, tokens } from '@fluentui/react-components';
 import { lightTheme, darkTheme } from './theme';
 import { useState } from 'react';
 import { Routes, Route, Navigate } from 'react-router-dom';
@@ -30,7 +30,10 @@ export default function App() {
 
   return (
     <FluentProvider theme={isDark ? darkTheme : lightTheme}>
-      <Stack tokens={{ childrenGap: 20 }} styles={{ root: { minHeight: '100vh' } }}>
+      <Stack
+        tokens={{ childrenGap: 20 }}
+        styles={{ root: { minHeight: '100vh', backgroundColor: tokens.colorNeutralBackground2 } }}
+      >
         <Navbar isDark={isDark} setIsDark={setIsDark} />
         <Routes>
           <Route path="/" element={<Home />} />

--- a/platforma/src/components/PageLayout.jsx
+++ b/platforma/src/components/PageLayout.jsx
@@ -1,12 +1,22 @@
 import { Stack } from '@fluentui/react';
-import { Text } from '@fluentui/react-components';
+import { Text, makeStyles, shorthands, tokens } from '@fluentui/react-components';
+
+const useStyles = makeStyles({
+  container: {
+    width: '100%',
+    maxWidth: '1200px',
+    margin: '0 auto',
+    ...shorthands.padding('20px'),
+    backgroundColor: tokens.colorNeutralBackground1,
+    ...shorthands.borderRadius(tokens.borderRadiusMedium),
+    boxShadow: tokens.shadow4,
+  },
+});
 
 export default function PageLayout({ title, children }) {
+  const styles = useStyles();
   return (
-    <Stack
-      tokens={{ childrenGap: 20 }}
-      styles={{ root: { width: '100%', maxWidth: 1200, margin: '0 auto', padding: 20 } }}
-    >
+    <Stack tokens={{ childrenGap: 20 }} className={styles.container}>
       {title && (
         <Text as="h1" size={800} block>
           {title}


### PR DESCRIPTION
## Summary
- apply theme tokens to App layout to give a neutral page background
- style PageLayout with Fluent UI tokens for a distinct content surface

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f76cdf7648326a7d0d68cc9851aef